### PR TITLE
[#5] 공통 Modal 컴포넌트 구현

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,6 +25,7 @@ export default function RootLayout({
       className={pretendard.className}
     >
       <body>
+        <div id='modal' />
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -1,0 +1,26 @@
+@import "@/styles/_index";
+
+.container {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  background: rgb(0 0 0 / 80%);
+}
+
+.box {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  align-items: center;
+  color: $white-100;
+  justify-content: center;
+  background: $black-200;
+
+  @include rounded-sm;
+}

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -18,8 +18,8 @@
   flex-direction: column;
   gap: 2rem;
   align-items: center;
-  color: $white-100;
   justify-content: center;
+  color: $white-100;
   background: $black-200;
 
   @include rounded-sm;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import ReactDOM from "react-dom";
-import useEscapeKeydown from "@/hooks/useEscapeKeydown";
+import useKeydown from "@/hooks/useKeydown";
 import useOutsideClick from "@/hooks/useOutsideClick";
 import usePreventScroll from "@/hooks/usePreventScroll";
 import styles from "./Modal.module.scss";
@@ -26,7 +26,7 @@ function ModalPortal({ children }: { children: React.ReactNode }) {
 export default function Modal({ children, onClose }: ModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   useOutsideClick(modalRef, onClose);
-  useEscapeKeydown(onClose);
+  useKeydown("Escape", onClose);
   usePreventScroll();
 
   return (

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import ReactDOM from "react-dom";
+import useEscapeKeydown from "@/hooks/useEscapeKeydown";
+import useOutsideClick from "@/hooks/useOutsideClick";
+import usePreventScroll from "@/hooks/usePreventScroll";
+import styles from "./Modal.module.scss";
+
+type ModalProps = {
+  children: React.ReactNode;
+  onClose: () => void;
+};
+
+function ModalPortal({ children }: { children: React.ReactNode }) {
+  const [element, setElement] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    setElement(document.getElementById("modal"));
+  }, []);
+
+  if (!element) return null;
+  return ReactDOM.createPortal(children, element) as JSX.Element;
+}
+
+export default function Modal({ children, onClose }: ModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  useOutsideClick(modalRef, onClose);
+  useEscapeKeydown(onClose);
+  usePreventScroll();
+
+  return (
+    <ModalPortal>
+      <section className={styles.container}>
+        <div
+          className={styles.box}
+          ref={modalRef}
+        >
+          {children}
+        </div>
+      </section>
+    </ModalPortal>
+  );
+}

--- a/src/hooks/useEscapeKeydown.ts
+++ b/src/hooks/useEscapeKeydown.ts
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+
+const useEscapeKeydown = (callback: () => void) => {
+  useEffect(() => {
+    const handleEscapeKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        callback();
+      }
+    };
+
+    document.addEventListener("keydown", handleEscapeKeyDown);
+
+    return () => document.removeEventListener("keydown", handleEscapeKeyDown);
+  }, [callback]);
+};
+
+export default useEscapeKeydown;

--- a/src/hooks/useKeydown.ts
+++ b/src/hooks/useKeydown.ts
@@ -1,9 +1,9 @@
 import { useEffect } from "react";
 
-const useEscapeKeydown = (callback: () => void) => {
+const useKeydown = (key: string, callback: () => void) => {
   useEffect(() => {
     const handleEscapeKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
+      if (event.key === key) {
         callback();
       }
     };
@@ -11,7 +11,7 @@ const useEscapeKeydown = (callback: () => void) => {
     document.addEventListener("keydown", handleEscapeKeyDown);
 
     return () => document.removeEventListener("keydown", handleEscapeKeyDown);
-  }, [callback]);
+  }, [key, callback]);
 };
 
-export default useEscapeKeydown;
+export default useKeydown;

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -1,0 +1,15 @@
+import { RefObject, useEffect } from "react";
+
+const useOutsideClick = (ref: RefObject<HTMLElement>, callback: () => void) => {
+  useEffect(() => {
+    const handleOutSectionClick = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) callback();
+    };
+
+    document.addEventListener("click", handleOutSectionClick);
+
+    return () => document.removeEventListener("click", handleOutSectionClick);
+  }, [ref, callback]);
+};
+
+export default useOutsideClick;

--- a/src/hooks/usePreventScroll.ts
+++ b/src/hooks/usePreventScroll.ts
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+
+const usePreventScroll = () => {
+  const preventScroll = () => {
+    const currentScrollY = window.scrollY;
+    document.body.style.position = "fixed";
+    document.body.style.width = "100%";
+    document.body.style.top = `-${currentScrollY}px`;
+    document.body.style.overflowY = "scroll";
+    return currentScrollY;
+  };
+
+  const allowScroll = (prevScrollY: number) => {
+    document.body.style.position = "";
+    document.body.style.width = "";
+    document.body.style.top = "";
+    document.body.style.overflowY = "";
+    window.scrollTo(0, prevScrollY);
+  };
+
+  useEffect(() => {
+    const prevScrollY = preventScroll();
+    return () => {
+      allowScroll(prevScrollY);
+    };
+  }, []);
+};
+
+export default usePreventScroll;


### PR DESCRIPTION
## Description
- 공통으로 사용하기 위한 Modal 컴포넌트 구현
- 해당 컴포넌트를 이용하여 원하는 모달 컴포넌트를 생성: 아래와 같이 사용
```jsx
"use client";

//...

export default function ExampleModal() {
  const [isModal, setIsModal] = useState(true);
  const handleClose = () => setIsModal(false);
  return (
    <>
      (
      {isModal && (
        <Modal onClose={handleClose}>
          <div className={styles.container}>
            <h2 className={styles.title}>테스트 모달입니다.</h2>
            <p className={styles.description}>테스트중!</p>
            <Button onClick={handleClose} />
          </div>
        </Modal>
      )}
      )
    </>
  );
}

```

## Changes Made
- useEscapeKeydown 훅 생성
- useOutsideClick 훅 생성
- usePreventScroll 훅 생성
- @/src/app/layout.tsx 에 <div id='modal'> 생성 (ReactPortal활용을 위한)

## Screenshots
<img width="936" alt="image" src="https://github.com/Mogazoa-team20/mogazoa/assets/37425309/4ce8d744-a626-43f3-8e25-90101ded6c6d">


## IssueNumber
close #5 
