### PR TITLE
[#22] Statistics / Activity Card 컴포넌트 구현

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,8 +9,10 @@ export default function Home() {
   return (
     <div>
       <Statistics
-        title='별점 평균'
-        rating={4.9}
+        title='리뷰'
+        rating={4.5}
+        favoriteCount={4}
+        reviewCount={6}
         compare={props}
       />
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,20 +1,10 @@
-import Statistics from "@/components/Card/Statistics/Statistics";
+import Activity from "@/components/Card/Activity/Activity";
 
 export default function Home() {
-  const props = {
-    rating: 4.5,
-    favoriteCount: 4,
-    reviewCount: 4,
-  };
   return (
     <div>
-      <Statistics
-        title='리뷰'
-        rating={4.5}
-        favoriteCount={4}
-        reviewCount={6}
-        compare={props}
-      />
+      <div>adf</div>
+      <Activity title='별점 평균' />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,18 @@
+import Statistics from "@/components/Card/Statistics/Statistics";
+
 export default function Home() {
-  return <div>Hello</div>;
+  const props = {
+    rating: 4.5,
+    favoriteCount: 4,
+    reviewCount: 4,
+  };
+  return (
+    <div>
+      <Statistics
+        title='별점 평균'
+        rating={4.9}
+        categoryMetric={props}
+      />
+    </div>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ export default function Home() {
       <Statistics
         title='별점 평균'
         rating={4.9}
-        categoryMetric={props}
+        compare={props}
       />
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,3 @@
-import Activity from "@/components/Card/Activity/Activity";
-
 export default function Home() {
-  return (
-    <div>
-      <div>adf</div>
-      <Activity title='별점 평균' />
-    </div>
-  );
+  return <div>Hello</div>;
 }

--- a/src/components/Card/Activity/Activity.module.scss
+++ b/src/components/Card/Activity/Activity.module.scss
@@ -3,52 +3,39 @@
 
 .container {
   display: inline-flex;
-  padding: 30px 74px;
+  padding: 30px 105px;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+
+  max-width: 300px;
+
+  gap: 20px;
 
   @include rounded-lg;
   background: $black-200;
   border: 1px solid $gray-300;
 
   @include respond-to(tablet) {
-    padding: 30px 43px;
-  }
-
-  @include respond-to(mobile) {
-    display: flex;
-    width: 335px;
-    padding: 20px;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 6px;
-  }
-}
-.mobileBox {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-
-  @include respond-to(mobile) {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 10px;
+    padding: 20px 21px;
+    gap: 15px;
   }
 }
 
 .title {
-  color: $white-100;
-  font-size: 18px;
+  width: 91px;
+  text-align: center;
+  color: $gray-100;
+  gap: 5px;
+  @include text-normal;
 
   @include respond-to(tablet) {
-    @include text-normal;
-  }
-
-  @include respond-to(mobile) {
     @include text-sm;
+  }
+  @include respond-to(mobile) {
+    display: flex;
+    width: 58px;
+    flex-direction: column;
   }
 }
 
@@ -56,18 +43,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 20px 0;
 
   span {
     @include text-xl;
-    color: $gray-100;
+    color: $white-100;
 
     @include respond-to(tablet) {
       font-size: 20px;
-    }
-
-    @include respond-to(mobile) {
-      @include text-normal;
     }
   }
 
@@ -85,28 +67,5 @@
   @include respond-to(tablet) {
     width: 20px;
     height: 20px;
-  }
-
-  @include respond-to(mobile) {
-    width: 19px;
-    height: 19px;
-  }
-}
-
-.description {
-  width: 150px;
-  text-align: center;
-  color: $gray-200;
-  @include text-sm;
-  line-height: 20px;
-
-  strong {
-    color: $white-100;
-    white-space: pre-line;
-  }
-
-  @include respond-to(mobile) {
-    width: auto;
-    @include text-xs;
   }
 }

--- a/src/components/Card/Activity/Activity.module.scss
+++ b/src/components/Card/Activity/Activity.module.scss
@@ -1,0 +1,112 @@
+@import "@/styles/_index";
+@import "@/styles/_media";
+
+.container {
+  display: inline-flex;
+  padding: 30px 74px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  @include rounded-lg;
+  background: $black-200;
+  border: 1px solid $gray-300;
+
+  @include respond-to(tablet) {
+    padding: 30px 43px;
+  }
+
+  @include respond-to(mobile) {
+    display: flex;
+    width: 335px;
+    padding: 20px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+}
+.mobileBox {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  @include respond-to(mobile) {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 10px;
+  }
+}
+
+.title {
+  color: $white-100;
+  font-size: 18px;
+
+  @include respond-to(tablet) {
+    @include text-normal;
+  }
+
+  @include respond-to(mobile) {
+    @include text-sm;
+  }
+}
+
+.contentBox {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px 0;
+
+  span {
+    @include text-xl;
+    color: $gray-100;
+
+    @include respond-to(tablet) {
+      font-size: 20px;
+    }
+
+    @include respond-to(mobile) {
+      @include text-normal;
+    }
+  }
+
+  @include respond-to(mobile) {
+    padding: 0;
+  }
+}
+
+.imageBox {
+  position: relative;
+  width: 24px;
+  height: 24px;
+  margin-right: 5px;
+
+  @include respond-to(tablet) {
+    width: 20px;
+    height: 20px;
+  }
+
+  @include respond-to(mobile) {
+    width: 19px;
+    height: 19px;
+  }
+}
+
+.description {
+  width: 150px;
+  text-align: center;
+  color: $gray-200;
+  @include text-sm;
+  line-height: 20px;
+
+  strong {
+    color: $white-100;
+    white-space: pre-line;
+  }
+
+  @include respond-to(mobile) {
+    width: auto;
+    @include text-xs;
+  }
+}

--- a/src/components/Card/Activity/Activity.tsx
+++ b/src/components/Card/Activity/Activity.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function Activity() {
+  return <div>Activity</div>;
+}

--- a/src/components/Card/Activity/Activity.tsx
+++ b/src/components/Card/Activity/Activity.tsx
@@ -3,11 +3,11 @@
 import Image from "next/image";
 import React from "react";
 import Category from "@/components/Chip/Category/Category";
-import { STAR_ACTIVE_ICON, SAVE_ICON, BUBBLE_ICON } from "@/utils/constant";
+import { STAR_ACTIVE_ICON, BUBBLE_ICON } from "@/utils/constant";
 import styles from "./Activity.module.scss";
 
 type ActivityProps = {
-  title: "별점 평균" | "리뷰" | "카테고리";
+  title: "남긴 별점 평균" | "남긴 리뷰" | "관심 카테고리";
   averageRating?: number;
   reviewCount?: number;
   chipCategoty?: MostFavoriteCategoryProps;
@@ -21,25 +21,37 @@ type MostFavoriteCategoryProps = {
 export default function Activity({ title, averageRating, reviewCount, chipCategoty }: ActivityProps) {
   let changeImageSrc: string | undefined;
   let mainContent: number | undefined;
+  let namgin: string | undefined;
+  let namuji: string | undefined;
+
+  if (title.length > 5) {
+    namuji = title.slice(3);
+    namgin = title.slice(0, 3);
+  } else {
+    namgin = title;
+    namuji = "";
+  }
+
   switch (title) {
-    case "별점 평균":
+    case "남긴 별점 평균":
       changeImageSrc = STAR_ACTIVE_ICON;
       mainContent = averageRating;
       break;
-    case "리뷰":
-      changeImageSrc = SAVE_ICON;
-      mainContent = reviewCount;
-      break;
-    case "카테고리":
+    case "남긴 리뷰":
       changeImageSrc = BUBBLE_ICON;
-      mainContent = chipCategoty?.id;
+      mainContent = reviewCount;
       break;
   }
 
   return (
     <div className={styles.container}>
-      <div className={styles.mobileBox}>
-        <div className={styles.title}>{title}</div>
+      <div className={styles.title}>
+        <span>{namgin}</span>
+        <span>{namuji}</span>
+      </div>
+      {title === "관심 카테고리" ? (
+        <Category>{chipCategoty?.name}</Category>
+      ) : (
         <div className={styles.contentBox}>
           <figure className={styles.imageBox}>
             <Image
@@ -50,8 +62,7 @@ export default function Activity({ title, averageRating, reviewCount, chipCatego
           </figure>
           <span>{mainContent}</span>
         </div>
-        <Category>전자기기</Category>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/components/Card/Activity/Activity.tsx
+++ b/src/components/Card/Activity/Activity.tsx
@@ -1,5 +1,57 @@
+/* eslint-disable default-case */ // swtich(title) -> 여기 기본값을 안주기 위한 주석
+/* eslint-disable react/require-default-props */ // type에 ? 연산자 추가하기 위한 주석
+import Image from "next/image";
 import React from "react";
+import Category from "@/components/Chip/Category/Category";
+import { STAR_ACTIVE_ICON, SAVE_ICON, BUBBLE_ICON } from "@/utils/constant";
+import styles from "./Activity.module.scss";
 
-export default function Activity() {
-  return <div>Activity</div>;
+type ActivityProps = {
+  title: "별점 평균" | "리뷰" | "카테고리";
+  averageRating?: number;
+  reviewCount?: number;
+  chipCategoty?: MostFavoriteCategoryProps;
+};
+
+type MostFavoriteCategoryProps = {
+  name: string;
+  id: number;
+};
+
+export default function Activity({ title, averageRating, reviewCount, chipCategoty }: ActivityProps) {
+  let changeImageSrc: string | undefined;
+  let mainContent: number | undefined;
+  switch (title) {
+    case "별점 평균":
+      changeImageSrc = STAR_ACTIVE_ICON;
+      mainContent = averageRating;
+      break;
+    case "리뷰":
+      changeImageSrc = SAVE_ICON;
+      mainContent = reviewCount;
+      break;
+    case "카테고리":
+      changeImageSrc = BUBBLE_ICON;
+      mainContent = chipCategoty?.id;
+      break;
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.mobileBox}>
+        <div className={styles.title}>{title}</div>
+        <div className={styles.contentBox}>
+          <figure className={styles.imageBox}>
+            <Image
+              src={changeImageSrc as string}
+              alt='title'
+              fill
+            />
+          </figure>
+          <span>{mainContent}</span>
+        </div>
+        <Category>전자기기</Category>
+      </div>
+    </div>
+  );
 }

--- a/src/components/Card/Statistics/Statistics.module.scss
+++ b/src/components/Card/Statistics/Statistics.module.scss
@@ -7,8 +7,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 10px;
-
+  
   @include rounded-lg;
   background: $black-200;
   border: 1px solid $gray-300;
@@ -27,8 +26,14 @@
   }
 }
 .mobileBox {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
   @include respond-to(mobile) {
     display: flex;
+    flex-direction: row;
     align-items: center;
     gap: 10px;
   }

--- a/src/components/Card/Statistics/Statistics.module.scss
+++ b/src/components/Card/Statistics/Statistics.module.scss
@@ -2,24 +2,49 @@
 @import "@/styles/_media";
 
 .container {
-  display: flex;
+  display: inline-flex;
   padding: 30px 74px;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 10px;
 
-  width: 300px;
-  height: 190px;
-
   @include rounded-lg;
   background: $black-200;
   border: 1px solid $gray-300;
+
+  @include respond-to(tablet) {
+    padding: 30px 43px;
+  }
+
+  @include respond-to(mobile) {
+    display: flex;
+    width: 335px;
+    padding: 20px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+}
+.mobileBox {
+  @include respond-to(mobile) {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
 }
 
 .title {
   color: $white-100;
   font-size: 18px;
+
+  @include respond-to(tablet) {
+    @include text-normal;
+  }
+
+  @include respond-to(mobile) {
+    @include text-sm;
+  }
 }
 
 .contentBox {
@@ -31,14 +56,52 @@
   span {
     @include text-xl;
     color: $gray-100;
+
+    @include respond-to(tablet) {
+      font-size: 20px;
+    }
+
+    @include respond-to(mobile) {
+      @include text-normal;
+    }
+  }
+
+  @include respond-to(mobile) {
+    padding: 0;
+  }
+}
+
+.imageBox {
+  position: relative;
+  width: 24px;
+  height: 24px;
+  margin-right: 5px;
+
+  @include respond-to(tablet) {
+    width: 20px;
+    height: 20px;
+  }
+
+  @include respond-to(mobile) {
+    width: 19px;
+    height: 19px;
   }
 }
 
 .description {
+  width: 150px;
+  text-align: center;
   color: $gray-200;
   @include text-sm;
+  line-height: 20px;
 
   strong {
     color: $white-100;
+    white-space: pre-line;
+  }
+
+  @include respond-to(mobile) {
+    width: auto;
+    @include text-xs;
   }
 }

--- a/src/components/Card/Statistics/Statistics.module.scss
+++ b/src/components/Card/Statistics/Statistics.module.scss
@@ -1,0 +1,44 @@
+@import "@/styles/_index";
+@import "@/styles/_media";
+
+.container {
+  display: flex;
+  padding: 30px 74px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+
+  width: 300px;
+  height: 190px;
+
+  @include rounded-lg;
+  background: $black-200;
+  border: 1px solid $gray-300;
+}
+
+.title {
+  color: $white-100;
+  font-size: 18px;
+}
+
+.contentBox {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px 0;
+
+  span {
+    @include text-xl;
+    color: $gray-100;
+  }
+}
+
+.description {
+  color: $gray-200;
+  @include text-sm;
+
+  strong {
+    color: $white-100;
+  }
+}

--- a/src/components/Card/Statistics/Statistics.tsx
+++ b/src/components/Card/Statistics/Statistics.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function Statistics() {
+  return <div>Statistics</div>;
+}

--- a/src/components/Card/Statistics/Statistics.tsx
+++ b/src/components/Card/Statistics/Statistics.tsx
@@ -46,20 +46,23 @@ export default function Statistics({ title, rating, reviewCount, favoriteCount, 
 
   return (
     <div className={styles.container}>
-      <div className={styles.title}>{title}</div>
-      <figure className={styles.contentBox}>
-        <Image
-          src={changeImageSrc as string}
-          alt='title'
-          width={24}
-          height={24}
-        />
-        <span>{mainContent}</span>
-      </figure>
+      <div className={styles.mobileBox}>
+        <div className={styles.title}>{title}</div>
+        <div className={styles.contentBox}>
+          <figure className={styles.imageBox}>
+            <Image
+              src={changeImageSrc as string}
+              alt='title'
+              fill
+            />
+          </figure>
+          <span>{mainContent}</span>
+        </div>
+      </div>
       {title === "별점 평균" ? (
         <span className={styles.description}>
-          같은 카테고리 제품들보다 <br />
-          <strong>{compareResult}점 </strong>
+          같은 카테고리 제품들보다
+          <strong> {compareResult}점 </strong>
           {mainContent! > compareItemResult! ? "높아" : "낮아"}요!
         </span>
       ) : (

--- a/src/components/Card/Statistics/Statistics.tsx
+++ b/src/components/Card/Statistics/Statistics.tsx
@@ -10,37 +10,39 @@ type StatisticsProps = {
   rating?: number;
   reviewCount?: number;
   favoriteCount?: number;
-  categoryMetric?: {
-    rating: number;
-    favoriteCount: number;
-    reviewCount: number;
-  };
+  compare: DataCompareProps;
 };
 
-export default function Statistics({ title, rating, reviewCount, favoriteCount, categoryMetric }: StatisticsProps) {
+type DataCompareProps = {
+  rating: number;
+  favoriteCount: number;
+  reviewCount: number;
+};
+
+export default function Statistics({ title, rating, reviewCount, favoriteCount, compare }: StatisticsProps) {
   let changeImageSrc: string | undefined;
   let mainContent: number | undefined;
   let compareItemResult: number | undefined;
+  let compareResult: number | undefined;
 
   switch (title) {
     case "별점 평균":
       changeImageSrc = STAR_ACTIVE_ICON;
       mainContent = rating;
-      compareItemResult = categoryMetric?.rating;
+      compareItemResult = compare?.rating;
+      compareResult = parseFloat(Math.abs(mainContent! - compareItemResult!).toFixed(1));
       break;
     case "찜":
       changeImageSrc = SAVE_ICON;
       mainContent = favoriteCount;
-      compareItemResult = categoryMetric?.favoriteCount;
+      compareItemResult = compare?.favoriteCount;
       break;
     case "리뷰":
       changeImageSrc = BUBBLE_ICON;
       mainContent = reviewCount;
-      compareItemResult = categoryMetric?.reviewCount;
+      compareItemResult = compare?.reviewCount;
       break;
   }
-
-  const isValidComparison = typeof mainContent === "number" && typeof compareItemResult === "number";
 
   return (
     <div className={styles.container}>
@@ -54,14 +56,18 @@ export default function Statistics({ title, rating, reviewCount, favoriteCount, 
         />
         <span>{mainContent}</span>
       </figure>
-      {isValidComparison ? (
+      {title === "별점 평균" ? (
         <span className={styles.description}>
           같은 카테고리 제품들보다 <br />
-          <strong>{parseFloat(Math.abs(mainContent! - compareItemResult!).toFixed(1))}</strong> 더{" "}
+          <strong>{compareResult}점 </strong>
           {mainContent! > compareItemResult! ? "높아" : "낮아"}요!
         </span>
       ) : (
-        <span>비교할 수 없는 데이터입니다.</span>
+        <span className={styles.description}>
+          같은 카테고리 제품들보다 <br />
+          <strong>{compareResult?.toFixed(0)}개 </strong>
+          {mainContent! > compareItemResult! ? "높아" : "낮아"}요!
+        </span>
       )}
     </div>
   );

--- a/src/components/Card/Statistics/Statistics.tsx
+++ b/src/components/Card/Statistics/Statistics.tsx
@@ -1,5 +1,67 @@
+/* eslint-disable default-case */
+/* eslint-disable react/require-default-props */
+import Image from "next/image";
 import React from "react";
+import { STAR_ICON, SAVE_ICON, BUBBLE_ICON } from "@/utils/constant";
 
-export default function Statistics() {
-  return <div>Statistics</div>;
+type StatisticsProps = {
+  title: "별점 평균" | "찜" | "리뷰";
+  rating?: number;
+  reviewCount?: number;
+  favoriteCount?: number;
+  categoryMetric?: {
+    rating: number;
+    favoriteCount: number;
+    reviewCount: number;
+  };
+};
+
+export default function Statistics({ title, rating, reviewCount, favoriteCount, categoryMetric }: StatisticsProps) {
+  let changeImageSrc: string | undefined;
+  let mainContent: number | undefined;
+  let compareItemResult: number | undefined;
+
+  switch (title) {
+    case "별점 평균":
+      changeImageSrc = STAR_ICON;
+      mainContent = rating;
+      compareItemResult = categoryMetric?.rating;
+      break;
+    case "찜":
+      changeImageSrc = SAVE_ICON;
+      mainContent = favoriteCount;
+      compareItemResult = categoryMetric?.favoriteCount;
+      break;
+    case "리뷰":
+      changeImageSrc = BUBBLE_ICON;
+      mainContent = reviewCount;
+      compareItemResult = categoryMetric?.reviewCount;
+      break;
+  }
+
+  const isValidComparison = typeof mainContent === "number" && typeof compareItemResult === "number";
+
+  return (
+    <div>
+      <div>{title}</div>
+      <figure>
+        <Image
+          src={changeImageSrc as string}
+          alt='title'
+          width={24}
+          height={24}
+        />
+        <span>{mainContent}</span>
+      </figure>
+      {isValidComparison ? (
+        <span>
+          같은 카테고리 제품들보다 <br />
+          <strong>{Math.abs(mainContent! - compareItemResult!)}</strong> 더{" "}
+          {mainContent! > compareItemResult! ? "높아" : "낮아"}요!
+        </span>
+      ) : (
+        <span>비교할 수 없는 데이터입니다.</span>
+      )}
+    </div>
+  );
 }

--- a/src/components/Card/Statistics/Statistics.tsx
+++ b/src/components/Card/Statistics/Statistics.tsx
@@ -36,11 +36,13 @@ export default function Statistics({ title, rating, reviewCount, favoriteCount, 
       changeImageSrc = SAVE_ICON;
       mainContent = favoriteCount;
       compareItemResult = compare?.favoriteCount;
+      compareResult = parseFloat(Math.abs(mainContent! - compareItemResult!).toFixed(0));
       break;
     case "리뷰":
       changeImageSrc = BUBBLE_ICON;
       mainContent = reviewCount;
       compareItemResult = compare?.reviewCount;
+      compareResult = parseFloat(Math.abs(mainContent! - compareItemResult!).toFixed(0));
       break;
   }
 
@@ -67,8 +69,8 @@ export default function Statistics({ title, rating, reviewCount, favoriteCount, 
         </span>
       ) : (
         <span className={styles.description}>
-          같은 카테고리 제품들보다 <br />
-          <strong>{compareResult?.toFixed(0)}개 </strong>
+          같은 카테고리 제품들보다
+          <strong> {compareResult}개 </strong>
           {mainContent! > compareItemResult! ? "높아" : "낮아"}요!
         </span>
       )}

--- a/src/components/Card/Statistics/Statistics.tsx
+++ b/src/components/Card/Statistics/Statistics.tsx
@@ -14,9 +14,9 @@ type StatisticsProps = {
 };
 
 type DataCompareProps = {
-  rating: number;
-  favoriteCount: number;
-  reviewCount: number;
+  rating?: number;
+  favoriteCount?: number;
+  reviewCount?: number;
 };
 
 export default function Statistics({ title, rating, reviewCount, favoriteCount, compare }: StatisticsProps) {

--- a/src/components/Card/Statistics/Statistics.tsx
+++ b/src/components/Card/Statistics/Statistics.tsx
@@ -2,7 +2,8 @@
 /* eslint-disable react/require-default-props */
 import Image from "next/image";
 import React from "react";
-import { STAR_ICON, SAVE_ICON, BUBBLE_ICON } from "@/utils/constant";
+import { STAR_ACTIVE_ICON, SAVE_ICON, BUBBLE_ICON } from "@/utils/constant";
+import styles from "./Statistics.module.scss";
 
 type StatisticsProps = {
   title: "별점 평균" | "찜" | "리뷰";
@@ -23,7 +24,7 @@ export default function Statistics({ title, rating, reviewCount, favoriteCount, 
 
   switch (title) {
     case "별점 평균":
-      changeImageSrc = STAR_ICON;
+      changeImageSrc = STAR_ACTIVE_ICON;
       mainContent = rating;
       compareItemResult = categoryMetric?.rating;
       break;
@@ -42,9 +43,9 @@ export default function Statistics({ title, rating, reviewCount, favoriteCount, 
   const isValidComparison = typeof mainContent === "number" && typeof compareItemResult === "number";
 
   return (
-    <div>
-      <div>{title}</div>
-      <figure>
+    <div className={styles.container}>
+      <div className={styles.title}>{title}</div>
+      <figure className={styles.contentBox}>
         <Image
           src={changeImageSrc as string}
           alt='title'
@@ -54,9 +55,9 @@ export default function Statistics({ title, rating, reviewCount, favoriteCount, 
         <span>{mainContent}</span>
       </figure>
       {isValidComparison ? (
-        <span>
+        <span className={styles.description}>
           같은 카테고리 제품들보다 <br />
-          <strong>{Math.abs(mainContent! - compareItemResult!)}</strong> 더{" "}
+          <strong>{parseFloat(Math.abs(mainContent! - compareItemResult!).toFixed(1))}</strong> 더{" "}
           {mainContent! > compareItemResult! ? "높아" : "낮아"}요!
         </span>
       ) : (

--- a/src/components/Chip/Category/Category.module.scss
+++ b/src/components/Chip/Category/Category.module.scss
@@ -1,4 +1,5 @@
 @import "@/styles/_index";
+@import "@/styles/_media";
 
 .container {
   display: flex;
@@ -10,7 +11,7 @@
   border-radius: 8px;
   font-size: 18px;
   font-weight: 500;
-  @include respond-to(mibile) {
+  @include respond-to(mobile) {
     padding: 4px 8px;
     font-size: 12px;
   }


### PR DESCRIPTION
## Description
Statistics / Activity Card 컴포넌트 구현했습니다.

```
<Statistics
  title= "별점 평균"
  rating= {4}
  compare = 객체
/>

<Activity 
  title= "남긴 별점 평균"
  rating = {4}
/>
```
둘 다 이런식으로 사용하시면 됩니다.
하나의 컴포넌트로 3가지 내용을 담으려다보니 조건문이 많이 들어갔습니다.
액티비티카드에서 모바일때문에 좀 막혔는데 좀 더 깔끔한 방법을 찾고싶습니다.
유빈님이 작업해주신 chip컴포넌트도 넣어서 작업했습니다.

## Changes Made
피그마 요구사항을 충족시킨듯합니다.

## Screenshots
![image](https://github.com/Mogazoa-team20/mogazoa/assets/33426203/e5bdf1ef-050b-4aef-a5cc-47984cab505b)
![image](https://github.com/Mogazoa-team20/mogazoa/assets/33426203/834aaadb-8ca5-4ef8-9100-4c71315d527b)
![image](https://github.com/Mogazoa-team20/mogazoa/assets/33426203/78cabfdf-e279-4ea6-9ec0-10d655c421b4)

## IssueNumber
[#22]
