### PR TITLE
auth 레이아웃 적용 + 공통 레이아웃 스타일 추가

### DIFF
--- a/src/app/(auth)/AuthLayout.module.scss
+++ b/src/app/(auth)/AuthLayout.module.scss
@@ -5,6 +5,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  gap: 60px;
   width: 640px;
   padding: 100px 0;
   min-height: calc(100vh - 88.5px);

--- a/src/app/(auth)/AuthLayout.module.scss
+++ b/src/app/(auth)/AuthLayout.module.scss
@@ -1,0 +1,21 @@
+@import "@/styles/_index";
+@import "@/styles/_media";
+
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 640px;
+  padding: 100px 0;
+  min-height: calc(100vh - 88.5px);
+
+  @include respond-to(tablet) {
+    max-width: minmax(440px, calc(100% - 304px));
+  }
+
+  @include respond-to(mobile) {
+    width: 100%;
+    min-height: calc(100vh - 70px);
+    padding: 0 20px;
+  }
+}

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,9 @@
+import styles from "./AuthLayout.module.scss";
+
+type AuthLayoutProps = {
+  children: React.ReactNode;
+};
+
+export default function AuthLayout({ children }: AuthLayoutProps) {
+  return <div className={styles.container}>{children}</div>;
+}

--- a/src/app/RootLayout.module.scss
+++ b/src/app/RootLayout.module.scss
@@ -1,0 +1,13 @@
+@import "@/styles/_index";
+
+.container {
+  width: 100vw;
+  min-height: 100vh;
+  background-color: $bg-black-100;
+
+  .main {
+    display: flex;
+    justify-content: center;
+    color: $white-100;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Gnb } from "@/components/Gnb";
 import Providers from "@/lib/Providers";
 import "@/styles/_reset.scss";
 import "@/styles/_common.scss";
+import styles from "./RootLayout.module.scss";
 
 export const metadata: Metadata = {
   title: "Mogazoa",
@@ -25,11 +26,11 @@ export default function RootLayout({
       lang='ko'
       className={pretendard.className}
     >
-      <body>
+      <body className={styles.container}>
         <div id='modal' />
         <Providers>
           <Gnb />
-          {children}
+          <main className={styles.main}>{children}</main>
         </Providers>
       </body>
     </html>


### PR DESCRIPTION
## Description
- auth (로그인/회원가입/간편 회원가입) 레이아웃 생성 및 적용 
- 전 페이지에서 공통으로 사용하는 스타일은 `RootLayout.module.css` 파일 생성하여 기본 레이아웃에 적용해두었습니다. 기본 상속되는 폰트 컬러(`#f1f1f5`), 배경 컬러(`#1c1c22`) 및 flex center, `min-height: 100vh` 등의 설정입니다.

## Changes Made
- 전체 페이지 공통 스타일 적용 
- auth 관련 페이지 공통 레이아웃 생성 및 스타일 적용 

## Screenshots
![image](https://github.com/Mogazoa-team20/mogazoa/assets/112041983/ff2aa77d-400a-4378-a3ce-54756bc3a711)

## IssueNumber
[#38 ]
