### PR TITLE
fix: UserItem 팔로워, 리뷰수 0일 경우 나타나지 않는 오류 수정 + 닉네임 글자 수 제한 추가

### DIFF
--- a/src/components/UserItem/UserItem.tsx
+++ b/src/components/UserItem/UserItem.tsx
@@ -15,8 +15,12 @@ type UserItemProps = {
 };
 
 export default function UserItem({ image, nickname, rating, followersCount, reviewCount, rank }: UserItemProps) {
-  const formattedFollowersCount = followersCount ? formatNumber(followersCount) : "";
-  const formattedReviewCount = reviewCount ? formatNumber(reviewCount) : "";
+  // 리뷰, 팔로워 값이 0일 경우를 대비한 조건 추가
+  const formattedFollowersCount =
+    String(followersCount) && followersCount !== undefined ? formatNumber(followersCount) : "";
+  const formattedReviewCount = String(reviewCount) && reviewCount !== undefined ? formatNumber(reviewCount) : "";
+
+  const formattedNickname = nickname.length > 7 ? `${nickname.slice(0, 6)}...` : nickname;
 
   return (
     <div className={styles.container}>
@@ -28,10 +32,10 @@ export default function UserItem({ image, nickname, rating, followersCount, revi
       <div className={styles.detailBox}>
         <div className={styles.userTitle}>
           {rank ? <Ranking>{String(rank)}</Ranking> : null}
-          <span className={styles.userNickname}>{nickname}</span>
+          <span className={styles.userNickname}>{formattedNickname}</span>
         </div>
         <div className={styles.userDesc}>
-          {followersCount && reviewCount ? (
+          {!rating && String(followersCount) && String(reviewCount) ? (
             <>
               <div className={styles.userDescItem}>
                 <span>팔로워</span>


### PR DESCRIPTION
## Description
- `UserItem` 컴포넌트를 `Ranking` 용으로 사용시에 팔로워, 리뷰 수가 0일 경우 표시되지 않는 오류를 수정했습니다.
- 유저 닉네임 생성 제한이 20자인데 UI에서 모든 닉네임 글자를 표시하는 것에 한계가 있어보여 최대 노출되는 닉네임 수를 7자로 변경했습니다. (7자 까지는 `가나다라마바사` 그대로 표현, 8자부터는 `가나다라마바...` 식으로 6자까지만 표시됩니다.) 

## Changes Made
- `UserItem` 컴포넌트 `followersCount`, `ReviewCount` 포맷팅 조건 추가 
- `nickname` 포맷팅 추가 

## Screenshots
![image](https://github.com/Mogazoa-team20/mogazoa/assets/112041983/f59f6baf-f1fa-40fd-817c-eab695cb0116)

## IssueNumber