### PR TITLE
Refactor Input 컴포넌트 수정

### DIFF
--- a/src/components/Input/Input.module.scss
+++ b/src/components/Input/Input.module.scss
@@ -1,10 +1,22 @@
 @import "@/styles/_index";
+@import "@/styles/_media";
 
 .container {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
   width: 40rem;
+  height: 5.2rem;
+  margin: 0.4rem 0;
+
+  @include respond-to(tablet) {
+    height: 4.6rem;
+  }
+
+  @include respond-to(mobile) {
+    height: 4.6rem;
+  }
 }
 
 .label {
@@ -13,7 +25,7 @@
 
 .input {
   width: 100%;
-  padding: 1rem;
+  padding: 23px 20px;
   color: $white-100;
   background: $black-200;
   border: none;
@@ -24,18 +36,14 @@
   }
 
   @include rounded-md;
-}
 
-.inputBox {
-  position: relative;
-}
+  @include respond-to(tablet) {
+    padding: 17px 20px;
+  }
 
-.eyeIcon {
-  position: absolute;
-  top: 50%;
-  right: 0.6rem;
-  cursor: pointer;
-  transform: translateY(-50%);
+  @include respond-to(mobile) {
+    padding: 17px 20px;
+  }
 }
 
 .error {
@@ -43,6 +51,9 @@
 }
 
 .errorMessage {
+  position: absolute;
+  bottom: 5px;
+  left: 0;
   color: $red-100;
 
   @include text-xs;

--- a/src/components/Input/Input.module.scss
+++ b/src/components/Input/Input.module.scss
@@ -61,3 +61,15 @@
 
   @include text-xs;
 }
+
+.inputBox {
+  position: relative;
+}
+
+.eyeIcon {
+  position: absolute;
+  top: 50%;
+  right: 0.6rem;
+  cursor: pointer;
+  transform: translateY(-50%);
+}

--- a/src/components/Input/Input.module.scss
+++ b/src/components/Input/Input.module.scss
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
-  width: 40rem;
+  width: 100%;
   height: 5.2rem;
   margin: 0.4rem 0;
 
@@ -36,13 +36,16 @@
   }
 
   @include rounded-md;
+  @include text-normal;
 
   @include respond-to(tablet) {
     padding: 17px 20px;
+    @include text-sm;
   }
 
   @include respond-to(mobile) {
     padding: 17px 20px;
+    @include text-xs;
   }
 }
 

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,70 +1,32 @@
-"use client";
-
-import Image from "next/image";
-import { useState } from "react";
-import { useFormContext } from "react-hook-form";
+import { Path, UseFormRegister, FieldValues, RegisterOptions, FieldErrors } from "react-hook-form";
 import cn from "@/utils/classNames";
-import { EYE_OFF_ICON, EYE_ON_ICON } from "@/utils/constant";
 import styles from "./Input.module.scss";
 
-type InputProps = {
-  name: string;
-  type?: "email" | "text" | "password";
-  label?: string;
-  placeholder?: string;
-  required?: string;
-  minLength?: { value: number; message: string };
-  maxLength?: { value: number; message: string };
-  pattern?: { value: RegExp; message: string };
-  validate?: { ["type"]: () => string };
-};
+type InputProps<T extends FieldValues> = {
+  name: Path<T>;
+  className?: string;
+  register: UseFormRegister<T>;
+  rules?: RegisterOptions;
+  errors?: FieldErrors<T>;
+} & React.InputHTMLAttributes<HTMLInputElement>;
 
-export default function Input({
+export default function Input<T extends FieldValues>({
   name,
-  label,
-  type,
-  placeholder,
-  required,
-  minLength,
-  maxLength,
-  pattern,
-  validate,
-}: InputProps) {
-  const {
-    register,
-    formState: { errors },
-  } = useFormContext();
-
-  const [showPassword, setShowPassword] = useState(false);
-  const handleEyeIconClick = () => setShowPassword((prev: boolean) => !prev);
-
+  className,
+  register,
+  rules,
+  errors,
+  ...rest
+}: InputProps<T>) {
+  const error = errors?.[name];
   return (
-    <div className={styles.container}>
-      <label
-        className={styles.label}
-        htmlFor={name}
-      >
-        {label}
-      </label>
-      <div className={styles.inputBox}>
-        <input
-          className={cn(styles.input, errors[name] && styles.error)}
-          type={showPassword ? "text" : type}
-          placeholder={placeholder}
-          {...register(name, { required, minLength, maxLength, pattern, validate })}
-        />
-        {type === "password" && (
-          <Image
-            className={styles.eyeIcon}
-            src={showPassword ? EYE_ON_ICON : EYE_OFF_ICON}
-            alt='eye'
-            onClick={handleEyeIconClick}
-            width={18}
-            height={18}
-          />
-        )}
-      </div>
-      {errors[name] && <p className={styles.errorMessage}>{errors[name]?.message?.toString()}</p>}
+    <div className={cn(className, styles.container)}>
+      <input
+        className={cn(styles.input, error && styles.error)}
+        {...register(name, rules)}
+        {...rest}
+      />
+      {error && <span className={styles.errorMessage}>{error.message as string}</span>}
     </div>
   );
 }

--- a/src/components/Input/PasswordInput.tsx
+++ b/src/components/Input/PasswordInput.tsx
@@ -1,0 +1,49 @@
+import Image from "next/image";
+import { useState } from "react";
+import { Path, UseFormRegister, FieldValues, RegisterOptions, FieldErrors } from "react-hook-form";
+import cn from "@/utils/classNames";
+import { EYE_OFF_ICON, EYE_ON_ICON } from "@/utils/constant";
+import styles from "./Input.module.scss";
+
+type PasswordInputProps<T extends FieldValues> = {
+  name: Path<T>;
+  className?: string;
+  register: UseFormRegister<T>;
+  rules?: RegisterOptions;
+  errors?: FieldErrors<T>;
+} & Omit<React.InputHTMLAttributes<HTMLInputElement>, "type">;
+
+export default function PasswordInput<T extends FieldValues>({
+  name,
+  className,
+  register,
+  rules,
+  errors,
+  ...rest
+}: PasswordInputProps<T>) {
+  const error = errors?.[name];
+  const [showPassword, setShowPassword] = useState(false);
+  const handleEyeIconClick = () => setShowPassword((prev: boolean) => !prev);
+
+  return (
+    <div className={cn(className, styles.container)}>
+      <div className={styles.inputBox}>
+        <input
+          className={cn(styles.input, error && styles.error)}
+          type={showPassword ? "text" : "password"}
+          {...register(name, rules)}
+          {...rest}
+        />
+        <Image
+          className={styles.eyeIcon}
+          src={showPassword ? EYE_ON_ICON : EYE_OFF_ICON}
+          alt='eye'
+          onClick={handleEyeIconClick}
+          width={18}
+          height={18}
+        />
+      </div>
+      {error && <span className={styles.errorMessage}>{error.message as string}</span>}
+    </div>
+  );
+}

--- a/src/utils/httpClient.ts
+++ b/src/utils/httpClient.ts
@@ -1,0 +1,44 @@
+export default class HttpClient {
+  baseUrl: string;
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl;
+  }
+
+  private async sendRequest<T, U>(path: string, method: string, body?: U, options: RequestInit = {}): Promise<T> {
+    try {
+      const requestOptions: RequestInit = {
+        method,
+        headers: { "Content-Type": "application/json", ...options.headers },
+        ...options,
+      };
+      if (body) {
+        requestOptions.body = JSON.stringify(body);
+      }
+      const response = await fetch(`${this.baseUrl}/${path}`, requestOptions);
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      return await response.json();
+    } catch (error) {
+      console.log(`fetch data error, ${error}`);
+      throw error;
+    }
+  }
+
+  async get<T>(path: string, options: RequestInit = {}): Promise<T> {
+    return this.sendRequest<T, never>(path, "GET", undefined, options);
+  }
+
+  async post<T, U>(path: string, body: U, options: RequestInit = {}): Promise<T> {
+    return this.sendRequest<T, U>(path, "POST", body, options);
+  }
+
+  async put<T, U>(path: string, body: U, options: RequestInit = {}): Promise<T> {
+    return this.sendRequest<T, U>(path, "PUT", body, options);
+  }
+
+  async delete<T>(path: string, options: RequestInit = {}): Promise<T> {
+    return this.sendRequest<T, never>(path, "DELETE", undefined, options);
+  }
+}


### PR DESCRIPTION
## Description
- Input 컴포넌트 구현방식 수정
- 기존에 useFormContext -> useForm 의 register와 options를 전달해주는 방식으로 변경

## Changes Made
다음과 같은 타입 사용
```tsx
type InputProps<T extends FieldValues> = {
  name: Path<T>;
  className?: string;
  register: UseFormRegister<T>;
  rules?: RegisterOptions;
  errors?: FieldErrors<T>;
} & React.InputHTMLAttributes<HTMLInputElement>;

```
다음과 같이 사용 register, rules(register validate 객체로 전달),
```tsx
//...
  const {
    register,
    formState: { errors },
  } = useForm<{ hello: string; password: string }>({ mode: "onBlur" });
//.....
  return (
        <Input
          name='hello'
          register={register}
          rules={{ required: "hello" }}
          errors={errors}
        />

```
- password용 Input 따로 컴포넌트 만들예정!(완료)

## IssueNumber
[#이슈번호]
