### PR TITLE
드롭다운 타입 지정

### DIFF
--- a/src/components/Dropdown/Dropdown.module.scss
+++ b/src/components/Dropdown/Dropdown.module.scss
@@ -50,10 +50,6 @@
     padding: 17px 20px;
   }
 
-  @include respond-to(mobile) {
-    padding: 17px 20px;
-  }
-
   &.focused,
   &.selected {
     color: $white-100;

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -2,23 +2,32 @@
 
 import Image from "next/image";
 import React, { useState } from "react";
-import { useController, Control } from "react-hook-form";
+import { Control, useController, FieldValues, Path, PathValue, RegisterOptions } from "react-hook-form";
 import cn from "@/utils/classNames";
 import { DROP_DOWN_ICON } from "@/utils/constant";
 import styles from "./Dropdown.module.scss";
 import { DropdownList } from "./DropdownList";
 import type { ItemType, VariantType } from "@/components/Dropdown/type";
 
-type DropdownProps = {
+type DropdownProps<T extends FieldValues> = {
   items: ItemType[];
-  control: Control;
-  name: string;
+  control: Control<T>;
+  name: Path<T>;
   variant?: VariantType;
   placeholder: string;
-  rules?: { required: string };
+  rules?: RegisterOptions<T>;
+  className?: string;
 };
 
-export default function Dropdown({ items, control, name, variant, placeholder, rules }: DropdownProps) {
+export default function Dropdown<T extends FieldValues>({
+  items,
+  control,
+  name,
+  variant,
+  placeholder,
+  rules,
+  className,
+}: DropdownProps<T>) {
   const [isOpen, setIsOpen] = useState(false);
 
   const {
@@ -30,7 +39,7 @@ export default function Dropdown({ items, control, name, variant, placeholder, r
     rules: {
       ...rules,
     },
-    defaultValue: "",
+    defaultValue: "" as PathValue<T, Path<T>>,
   });
 
   const selectedItem = items.find((item) => item.value === value);
@@ -50,14 +59,14 @@ export default function Dropdown({ items, control, name, variant, placeholder, r
   };
 
   return (
-    <div className={cn(styles.container, `${styles[`${variant}`]}`)}>
+    <div className={cn(styles.container, styles[`${variant}`], className)}>
       <div
         className={cn(
           styles.dropdownBox,
           isOpen && styles.focused,
           value && styles.selected,
           error && styles.error,
-          `${styles[`${variant}`]}`,
+          styles[`${variant}`],
         )}
         role='button'
         tabIndex={0}


### PR DESCRIPTION
## Description
form에서 사용시 control 타입에러가 발생해 드롭다운 컴포넌트에 타입 지정

## Changes Made
- 드롭다운 컴포넌트 타입 지정
- props로 className 받을 수 있도록 수정

## Screenshots

## IssueNumber
