### PR TITLE
Gnb 로그인 상태에 따른 ui 리팩토링

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import { getServerSession } from "next-auth/next";
-import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import { Gnb } from "@/components/Gnb";
+import authOptions from "@/lib/auth";
 import AuthProvider from "@/lib/AuthProvider";
 import Providers from "@/lib/Providers";
 import "@/styles/_reset.scss";
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
 };
 
 const pretendard = localFont({
-  src: "../../public/fonts/Pretendard-Regular.woff2",
+  src: "../../public/gfonts/Pretendard-Regular.woff2",
   display: "swap",
 });
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import { Gnb } from "@/components/Gnb";
 import AuthProvider from "@/lib/AuthProvider";
 import Providers from "@/lib/Providers";
@@ -17,11 +19,12 @@ const pretendard = localFont({
   display: "swap",
 });
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const session = await getServerSession(authOptions);
   return (
     <html
       lang='ko'
@@ -31,8 +34,9 @@ export default function RootLayout({
         <div id='modal' />
         <AuthProvider>
           <Providers>
-            <Gnb />
+            <Gnb initialSession={session} />
             <main className={styles.main}>{children}</main>
+            {/* {session && <FloatingButton />} */}
           </Providers>
         </AuthProvider>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
 };
 
 const pretendard = localFont({
-  src: "../../public/gfonts/Pretendard-Regular.woff2",
+  src: "../../public/fonts/Pretendard-Regular.woff2",
   display: "swap",
 });
 

--- a/src/components/Gnb/Gnb.tsx
+++ b/src/components/Gnb/Gnb.tsx
@@ -2,18 +2,30 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { Session } from "next-auth";
 import { useSession } from "next-auth/react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import cn from "@/utils/classNames";
 import { LOGO_IMAGE, MENU_TOGGLE_ICON, CLOSE_ICON } from "@/utils/constant";
 import styles from "./Gnb.module.scss";
 import { SearchInput } from "./SearchInput";
 
-export default function Gnb() {
+type GnbProps = {
+  initialSession: Session | null;
+};
+
+export default function Gnb({ initialSession }: GnbProps) {
+  const { data: session, status } = useSession();
+  const [currentSession, setCurrentSession] = useState(initialSession);
+
+  useEffect(() => {
+    if (status !== "loading" && initialSession !== session) {
+      setCurrentSession(session);
+    }
+  }, [session, initialSession, status]);
+
   const [isInputOpen, setInputOpen] = useState(false);
   const [isMenuOpen, setMenuOpen] = useState(false);
-
-  const { status } = useSession();
 
   const handleSearchClick = () => {
     setInputOpen(!isInputOpen);
@@ -62,7 +74,7 @@ export default function Gnb() {
             onClick={handleMenuClick}
           />
           <div className={cn(styles.userAction, isMenuOpen && styles.open)}>
-            {status === "authenticated" ? (
+            {currentSession ? (
               <>
                 <Link href='/compare'>비교하기</Link>
                 <Link href='/mypage'>내 프로필</Link>


### PR DESCRIPTION
## Description
로그인 상태를 클라이언트 사이드에서 관리하다보니
로그인 상태일 때 새로고침을 하면 null 상태 ui가 보이다 로그인 상태의 ui가 보이는 문제 해결

## Changes Made
서버 컴포넌트에서 로그인 상태를 가져와 Gnb 컴포넌트에 session을 넘겨는 방식으로 변경
근데 로그인 하고 메인 페이지로 리다이렉트되면 처음 로그인 상태로 보여서
useEffect로 서버와 클라이언트의 세션 상태를 동기화


## Screenshots

## IssueNumber
