### PR TITLE
[#65] 회원가입 폼/로직, 에러 안내 모달 컴포넌트 구현 

### DIFF
--- a/src/app/(auth)/_components/AlertModal/AlertModal.module.scss
+++ b/src/app/(auth)/_components/AlertModal/AlertModal.module.scss
@@ -1,0 +1,40 @@
+@import "@/styles/_index";
+@import "@/styles/_media";
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  padding: 40px;
+  width: 360px;
+
+  @include respond-to(mobile) {
+    width: minmax(320px, calc(100% - 40px));
+  }
+
+  .title {
+    @include text-xl;
+    @include font-bold;
+
+    @include respond-to(tablet) {
+      @include text-lg;
+    }
+  }
+
+  .message {
+    @include text-normal;
+    @include font-normal;
+
+    @include respond-to(tablet) {
+      @include text-sm;
+    }
+  }
+
+  .button {
+    width: auto;
+
+    @include respond-to(tablet) {
+      @include text-sm;
+    }
+  }
+}

--- a/src/app/(auth)/_components/AlertModal/AlertModal.tsx
+++ b/src/app/(auth)/_components/AlertModal/AlertModal.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import Button from "@/components/Button/Button";
+import Modal from "@/components/Modal/Modal";
+import styles from "./AlertModal.module.scss";
+
+type AlertModalProps = {
+  children: React.ReactNode;
+  handleClose: () => void;
+  isModal: boolean;
+};
+
+export default function AlertModal({ children, handleClose, isModal }: AlertModalProps) {
+  return (
+    <>
+      {isModal && (
+        <Modal onClose={handleClose}>
+          <div className={styles.container}>
+            <h2 className={styles.title}>Sign up Error 😣</h2>
+            <p className={styles.message}>{children}</p>
+            <Button
+              className={styles.button}
+              styleType='primary'
+              onClick={handleClose}
+            >
+              닫기
+            </Button>
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/src/app/(auth)/_components/AlertModal/index.ts
+++ b/src/app/(auth)/_components/AlertModal/index.ts
@@ -1,0 +1,1 @@
+export { default as AlertModal } from "./AlertModal";

--- a/src/app/(auth)/signup/_components/SignUpForm/SignUpForm.module.scss
+++ b/src/app/(auth)/signup/_components/SignUpForm/SignUpForm.module.scss
@@ -1,0 +1,46 @@
+@import "@/styles/_index";
+@import "@/styles/_media";
+
+.container,
+.inputList,
+.inputBox {
+  display: flex;
+  flex-direction: column;
+}
+
+.container {
+  gap: 30px;
+  width: 100%;
+
+  .inputList {
+    gap: 16px;
+
+    .inputBox {
+      gap: 8px;
+
+      .label {
+        @include text-normal;
+        @include font-normal;
+
+        @include respond-to(tablet) {
+          @include text-sm;
+        }
+      }
+    }
+
+    @include respond-to(mobile) {
+      gap: 8px;
+    }
+  }
+
+  .signUpButton {
+    width: auto;
+    padding: 21px;
+    @include text-lg;
+
+    @include respond-to(tablet) {
+      @include text-normal;
+      padding: 18px;
+    }
+  }
+}

--- a/src/app/(auth)/signup/_components/SignUpForm/SignUpForm.tsx
+++ b/src/app/(auth)/signup/_components/SignUpForm/SignUpForm.tsx
@@ -1,0 +1,183 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
+
+"use client";
+
+import { useRouter } from "next/navigation";
+import { signIn } from "next-auth/react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { AlertModal } from "@/app/(auth)/_components/AlertModal";
+import Button from "@/components/Button/Button";
+import Input from "@/components/Input/Input";
+import PasswordInput from "@/components/Input/PasswordInput";
+import styles from "./SignUpForm.module.scss";
+
+type SignUpFormData = {
+  email: string;
+  nickname: string;
+  password: string;
+  passwordConfirmation: string;
+};
+
+export default function SignUpForm() {
+  const [isModal, setIsModal] = useState(false);
+  const [modalMessage, setModalMessage] = useState("");
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { isValid, errors },
+  } = useForm<SignUpFormData>({ mode: "onBlur" });
+  const router = useRouter();
+
+  const handleModalClose = () => {
+    setIsModal(false);
+  };
+
+  /**
+   * @TODO signin 페이지 머지 후 상수 파일에 분리
+   */
+  const EMAIL_REGEX = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+  const PASSWORD_REGEX = /^[a-z0-9!@#$%^&*()_+\-=[\]{};:'"\\|,.<>/?`~]{8,}$/i;
+  const SIGNUP_VALIDATION = {
+    email: {
+      required: { value: true, message: "이메일은 필수 입력입니다." },
+      pattern: {
+        value: EMAIL_REGEX,
+        message: "이메일 형식으로 작성해주세요.",
+      },
+    },
+    nickname: {
+      required: { value: true, message: "닉네임은 필수 입력입니다." },
+      maxLength: { value: 20, message: "닉네임은 최대 20자까지 가능합니다." },
+    },
+    password: {
+      required: { value: true, message: "비밀번호는 필수 입력입니다." },
+      minLength: { value: 8, message: "비밀번호는 최소 8자 이상입니다." },
+      pattern: { value: PASSWORD_REGEX, message: "비밀번호는 숫자, 영문, 특수문자로만 이루어져야 합니다." },
+    },
+    passwordConfirmation: {
+      required: { value: true, message: "비밀번호 확인을 입력해주세요." },
+      validate: (value: string) => {
+        if (watch("password") !== value) {
+          return "비밀번호가 일치하지 않습니다.";
+        }
+        return true;
+      },
+    },
+  };
+
+  const onSubmit = async (data: SignUpFormData) => {
+    try {
+      const result = await signIn("signup", {
+        redirect: false,
+        email: data.email,
+        nickname: data.nickname,
+        password: data.password,
+        passwordConfirmation: data.passwordConfirmation,
+      });
+
+      if (result?.error) {
+        setModalMessage(result?.error);
+        setIsModal(true);
+      } else {
+        router.push("/");
+      }
+    } catch (error) {
+      /**
+       * @TODO : 일반적인 HTTP 통신 오류 에러 핸들링
+       */
+    }
+  };
+
+  return (
+    <>
+      <AlertModal
+        isModal={isModal}
+        handleClose={handleModalClose}
+      >
+        {modalMessage}
+      </AlertModal>
+      <form
+        className={styles.container}
+        onSubmit={handleSubmit(onSubmit)}
+      >
+        <div className={styles.inputList}>
+          <div className={styles.inputBox}>
+            <label
+              htmlFor='email'
+              className={styles.label}
+            >
+              이메일
+            </label>
+            <Input
+              id='email'
+              name='email'
+              type='email'
+              register={register}
+              rules={SIGNUP_VALIDATION.email}
+              errors={errors}
+              placeholder='이메일을 입력해 주세요'
+            />
+          </div>
+          <div className={styles.inputBox}>
+            <label
+              htmlFor='nickname'
+              className={styles.label}
+            >
+              닉네임
+            </label>
+            <Input
+              id='nickname'
+              name='nickname'
+              type='text'
+              register={register}
+              rules={SIGNUP_VALIDATION.nickname}
+              errors={errors}
+              placeholder='닉네임을 입력해주세요'
+            />
+          </div>
+          <div className={styles.inputBox}>
+            <label
+              htmlFor='password'
+              className={styles.label}
+            >
+              비밀번호
+            </label>
+            <PasswordInput
+              id='password'
+              name='password'
+              register={register}
+              rules={SIGNUP_VALIDATION.password}
+              errors={errors}
+              placeholder='비밀번호를 입력해 주세요'
+            />
+          </div>
+          <div className={styles.inputBox}>
+            <label
+              htmlFor='passwordConfirmation'
+              className={styles.label}
+            >
+              비밀번호 확인
+            </label>
+            <PasswordInput
+              id='passwordConfirmation'
+              name='passwordConfirmation'
+              register={register}
+              rules={SIGNUP_VALIDATION.passwordConfirmation}
+              errors={errors}
+              placeholder='비밀번호를 한번 더 입력해 주세요'
+            />
+          </div>
+        </div>
+        <Button
+          styleType='primary'
+          disabled={!isValid}
+          className={styles.signInButton}
+        >
+          가입하기
+        </Button>
+      </form>
+    </>
+  );
+}

--- a/src/app/(auth)/signup/_components/SignUpForm/SignUpForm.tsx
+++ b/src/app/(auth)/signup/_components/SignUpForm/SignUpForm.tsx
@@ -26,6 +26,7 @@ export default function SignUpForm() {
     register,
     handleSubmit,
     watch,
+    setError,
     formState: { isValid, errors },
   } = useForm<SignUpFormData>({ mode: "onBlur" });
   const router = useRouter();
@@ -78,8 +79,14 @@ export default function SignUpForm() {
       });
 
       if (result?.error) {
-        setModalMessage(result?.error);
+        setModalMessage(result.error);
         setIsModal(true);
+
+        if (result.error.includes("닉네임")) {
+          setError("nickname", { message: "이미 사용중인 닉네임입니다." });
+        } else if (result.error.includes("이메일")) {
+          setError("email", { message: "이미 사용중인 이메일입니다." });
+        }
       } else {
         router.push("/");
       }
@@ -90,6 +97,10 @@ export default function SignUpForm() {
     }
   };
 
+  /**
+   * AuthInput 컴포넌트 생성
+   * auth용 스타일링 파일 통합
+   */
   return (
     <>
       <AlertModal

--- a/src/app/(auth)/signup/_components/SignUpForm/index.ts
+++ b/src/app/(auth)/signup/_components/SignUpForm/index.ts
@@ -1,0 +1,1 @@
+export { default as SignUpForm } from "./SignUpForm";

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,0 +1,5 @@
+import { SignUpForm } from "./_components/SignUpForm";
+
+export default function SignUpPage() {
+  return <SignUpForm />;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -30,6 +30,45 @@ const authOptions: NextAuthOptions = {
         };
       },
     }),
+    Credentials({
+      id: "signup",
+      name: "signup",
+      credentials: {
+        email: { label: "email", type: "email", placeholder: "user@email.com" },
+        nickname: { label: "nickname", type: "text", placeholder: "nickname" },
+        password: { label: "password", type: "password", placeholder: "password" },
+        passwordConfirmation: { label: "passwordConfirmation", type: "password", placeholder: "password confirmation" },
+      },
+      async authorize(credentials) {
+        try {
+          const result = await fetch(`${process.env.BASE_URL}/auth/signUp`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              email: credentials?.email,
+              nickname: credentials?.nickname,
+              password: credentials?.password,
+              passwordConfirmation: credentials?.passwordConfirmation,
+            }),
+          });
+          const data = await result.json();
+          const user = data?.user;
+
+          if (result.ok && user) {
+            return {
+              ...user,
+              accessToken: data.accessToken,
+            };
+          }
+          return await Promise.reject(data);
+        } catch (error) {
+          const typedError = error as { message: string; details: { [key: string]: { message: string } } };
+          throw new Error(typedError?.message);
+        }
+      },
+    }),
   ],
   callbacks: {
     async jwt({ token, user }) {
@@ -51,6 +90,7 @@ const authOptions: NextAuthOptions = {
   },
   pages: {
     signIn: "/signin",
+    newUser: "/signup",
   },
   secret: process.env.SECRET,
 };


### PR DESCRIPTION
## Description
- 회원가입 폼 컴포넌트를 생성하고 내부 validation 및 로직을 구현했습니다. 
- `signin` 페이지 머지 후에 validation 상수 파일로 분리/`label`을 포함한 `input` 컴포넌트 생성 (`auth` 공통)/`auth`용 공통 스타일링 통합 파일 생성 예정입니다. 
- 회원가입 에러(닉네임/이메일 중복)가 발생할 경우 노출될 `AlertModal` 컴포넌트를 구현했습니다. 서버에서 받아온 에러메시지를 노출합니다. -> 나중에 팀 전체 알림 방향이 결정되어 변경이 필요할 경우 수정하겠습니다. (`toast` 등?)
- 인풋 컴포넌트에도 `setError`를 통해 해당하는 에러가 표시되게 했습니다. 

## Changes Made
- `SignUpForm`, `AlertModal` 컴포넌트 생성 및 스타일링
- `signup` 페이지 생성
- 회원가입 기능 구현 및 일부 에러 처리

## Screenshots
![회원가입폼](https://github.com/Mogazoa-team20/mogazoa/assets/112041983/fd57e021-3dc1-419e-b64e-62beb703dd42)

## IssueNumber
[#65 ]
