### PR TITLE
[#70] feat: 페이지 접근 권한 관리 middleware 파일 생성

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -52,7 +52,7 @@ const authOptions: NextAuthOptions = {
   pages: {
     signIn: "/signin",
   },
-  secret: process.env.SECRET,
+  secret: process.env.NEXTAUTH_SECRET,
 };
 
 export default authOptions;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getToken } from "next-auth/jwt";
+
+const MAIN_PAGE = process.env.NEXTAUTH_URL ?? "";
+const SIGNIN_PAGE = `${MAIN_PAGE}/signin`;
+const AUTH_PAGES = ["/signin", "/signup", "/oauth/signup"];
+const PROTECTED_PAGES = ["/compare"];
+
+export async function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  const token = await getToken({ req });
+  if (AUTH_PAGES.some((page) => pathname.startsWith(page))) {
+    if (token) {
+      return NextResponse.redirect(MAIN_PAGE);
+    }
+    return NextResponse.next();
+  }
+
+  if (PROTECTED_PAGES.some((page) => pathname.startsWith(page))) {
+    if (!token) {
+      return NextResponse.redirect(SIGNIN_PAGE);
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    {
+      source: "/((?!api|_next/static|_next/image|favicon.ico|server).*)",
+      missing: [
+        { type: "header", key: "next-router-prefetch" },
+        { type: "header", key: "purpose", value: "prefetch" },
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
## Description
- 로그인 상태에서 `/signin`, `/signup`, `/oauth/signup/*` 페이지에 접근할 경우 `/` 메인페이지로 리다이렉트합니다.
- 비로그인 상태에서 `/compare` 비교하기 페이지에 접근할 경우 `/signin` 로그인 페이지로 리다이렉트합니다. (추가할 페이지가 있다면 알려주세요!) 

## Changes Made
- `middleware.ts` 파일 생성 및 기능 구현 
- `next-auth`의 `secret key` 관련 환경 변수명을 `NEXTAUTH_SECRET`로 변경

## Screenshots
![미들웨어](https://github.com/Mogazoa-team20/mogazoa/assets/112041983/4637e566-1e33-468a-a7fd-201b711d1423)

## IssueNumber
[#70 ]
