### PR TITLE
Feat/text area

### DIFF
--- a/src/components/Input/TextArea.module.scss
+++ b/src/components/Input/TextArea.module.scss
@@ -1,4 +1,4 @@
-@import "@/styles/_index.scss";
+@import "@/styles/_index";
 
 .container {
   position: relative;
@@ -12,11 +12,11 @@
 }
 
 .textarea {
-  border: 1px solid $gray-200;
   padding: 8px;
-  background: $black-200;
   color: $white-100;
   resize: none;
+  background: $black-200;
+  border: 1px solid $gray-200;
 
   @include rounded-md;
 }
@@ -30,13 +30,14 @@
   bottom: -25px;
   left: 0;
   color: $red-100;
+
   @include text-xs;
 }
 
 .charCount {
   position: absolute;
-  bottom: 8px;
   right: 8px;
+  bottom: 8px;
   font-size: 12px;
   color: $gray-200;
 }

--- a/src/components/Input/TextArea.module.scss
+++ b/src/components/Input/TextArea.module.scss
@@ -1,0 +1,42 @@
+@import "@/styles/_index.scss";
+
+.container {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.default {
+  width: 20rem;
+  height: 8rem;
+}
+
+.textarea {
+  border: 1px solid $gray-200;
+  padding: 8px;
+  background: $black-200;
+  color: $white-100;
+  resize: none;
+
+  @include rounded-md;
+}
+
+.error {
+  outline: 1px solid $red-100;
+}
+
+.errorMessage {
+  position: absolute;
+  bottom: -25px;
+  left: 0;
+  color: $red-100;
+  @include text-xs;
+}
+
+.charCount {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  font-size: 12px;
+  color: $gray-200;
+}

--- a/src/components/Input/TextArea.tsx
+++ b/src/components/Input/TextArea.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import { Path, UseFormRegister, FieldValues, RegisterOptions, FieldErrors } from "react-hook-form";
+import cn from "@/utils/classNames";
+import styles from "./TextArea.module.scss";
+
+type TextAreaProps<T extends FieldValues> = {
+  name: Path<T>;
+  className?: string;
+  register: UseFormRegister<T>;
+  rules?: RegisterOptions;
+  errors?: FieldErrors<T>;
+  maxLength?: number;
+} & React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export default function TextArea<T extends FieldValues>({
+  name,
+  className,
+  register,
+  rules,
+  errors,
+  maxLength,
+  ...rest
+}: TextAreaProps<T>) {
+  const error = errors?.[name];
+  const [charCount, setCharCount] = useState(0);
+  const handleInputChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => setCharCount(event.target.value.length);
+  return (
+    <div className={styles.container}>
+      <textarea
+        className={cn(className || styles.default, styles.textarea, error && styles.error)}
+        {...register(name, { ...rules, onChange: handleInputChange })}
+        {...rest}
+      />
+      <div className={styles.charCount}>
+        {charCount}
+        {maxLength && `/${maxLength}`}
+      </div>
+      {error && <span className={styles.errorMessage}>{error.message as string}</span>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Description
- textArea 컴포넌트 구현
- className으로 width, height 스타일 or textArea에 넘기고자 하는 스타일 전송하여 스타일 조정

## Changes Made
- charCount기능이 있어서, maxLength를 props로 전달해야함.
- 전달하는김에 자체적으로 register에 maxLength value랑 message 넣어줄까 하다가 maxLength 제한하고싶으면 rules에 넣어서 사용하도록 유지 (메세지가 고정되거나 메세지를 또 프롭스로 받아야하는 케이스가 생겨서 별로인것 같아서 생각 바꿈!)
- 다른 의견 웰컴!

## Screenshots
<img width="352" alt="image" src="https://github.com/Mogazoa-team20/mogazoa/assets/37425309/10542748-b661-4daf-b9bd-98d1f2cb170e">

## IssueNumber
[#이슈번호]
