### PR TITLE
refactor: 상품 리스트 suspense 추가

### DIFF
--- a/src/app/_home/components/Main/Main.tsx
+++ b/src/app/_home/components/Main/Main.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useSearchParams, useRouter } from "next/navigation";
-import { useState } from "react";
+import { useState, Suspense } from "react";
 import { Category, CategoryList } from "@/_home/components/Category";
 import { PopularProducts, FilteredProducts } from "@/_home/components/Products";
 import { ReviewerRanking } from "@/_home/components/ReviewerRanking";
 import { QUERY } from "@/_home/constants";
 import CategoryFilter from "@/components/Chip/Category-filter/CategoryFilter";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { NoData } from "@/components/NoData";
 import cn from "@/utils/classNames";
 import { createQueryString, deleteQueryString } from "@/utils/createQueryString";
 import styles from "./Main.module.scss";
@@ -62,7 +64,11 @@ export default function Main({ categories, ranking, products }: MainProps) {
 
       <div className={styles.content}>
         {hasQueryParams ? (
-          <FilteredProducts category={category ?? null} />
+          <ErrorBoundary>
+            <Suspense fallback={<NoData message='Loading...' />}>
+              <FilteredProducts category={category ?? null} />
+            </Suspense>
+          </ErrorBoundary>
         ) : (
           <PopularProducts
             hotProducts={hotProducts.list.slice(0, 6)}

--- a/src/app/_home/components/Products/FilteredProducts/FilteredProducts.tsx
+++ b/src/app/_home/components/Products/FilteredProducts/FilteredProducts.tsx
@@ -10,6 +10,7 @@ import { useGetFilteredProducts } from "@/_home/hooks/useGetFilteredProducts";
 import { useQueryParams } from "@/app/_home/hooks/useQueryParams";
 import { Dropdown } from "@/components/Dropdown";
 import { ORDER, DROPDOWN } from "@/components/Dropdown/constants";
+import { NoData } from "@/components/NoData";
 import cn from "@/utils/classNames";
 import { createQueryString } from "@/utils/createQueryString";
 import styles from "./FilteredProducts.module.scss";
@@ -58,25 +59,25 @@ export default function FilteredProducts({ category }: FilteredProductsProps) {
 
   return (
     <div className={cn(styles.container)}>
-      <div className={cn(styles.content)}>
-        <div className={cn(styles.header)}>
-          <h2 className={cn(styles.headerText)}>{filteringText}</h2>
-          <Dropdown
-            items={ORDER.PRODUCT}
-            control={control}
-            name='order'
-            variant={DROPDOWN.ORDER}
-            placeholder={ORDER.PRODUCT[0].option}
-          />
-        </div>
-
-        {productData && (
-          <ProductList
-            list={productData}
-            lastRef={ref}
-          />
-        )}
+      <div className={cn(styles.header)}>
+        <h2 className={cn(styles.headerText)}>{filteringText}</h2>
+        <Dropdown
+          items={ORDER.PRODUCT}
+          control={control}
+          name='order'
+          variant={DROPDOWN.ORDER}
+          placeholder={ORDER.PRODUCT[0].option}
+        />
       </div>
+
+      {productData.length !== 0 ? (
+        <ProductList
+          list={productData}
+          lastRef={ref}
+        />
+      ) : (
+        <NoData message='등록된 상품이 없습니다.' />
+      )}
     </div>
   );
 }

--- a/src/app/_home/hooks/useGetFilteredProducts.ts
+++ b/src/app/_home/hooks/useGetFilteredProducts.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import type { ProductType } from "@/types/global";
 
 const fetchProducts = async (pageParam: number, queryString: string) => {
@@ -12,7 +12,7 @@ const fetchProducts = async (pageParam: number, queryString: string) => {
 };
 
 export const useGetFilteredProducts = (queryString: string) => {
-  return useInfiniteQuery({
+  return useSuspenseInfiniteQuery({
     queryKey: ["products", queryString],
     queryFn: async ({ pageParam }) => fetchProducts(pageParam, queryString),
     select: (data): ProductType[] => data.pages.map((page) => page.list).flat(),

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import React, { Component, ErrorInfo, ReactNode } from "react";
+import { NoData } from "@/components/NoData";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: null,
+    };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("error:", error, errorInfo);
+  }
+
+  render() {
+    const { hasError, error } = this.state;
+    const { children } = this.props;
+
+    if (hasError) {
+      return <NoData message={error?.message ?? "알 수 없는 에러가 발생했습니다."} />;
+    }
+
+    return children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/ErrorBoundary/index.ts
+++ b/src/components/ErrorBoundary/index.ts
@@ -1,0 +1,1 @@
+export { default as ErrorBoundary } from "./ErrorBoundary";

--- a/src/components/NoData/NoData.module.scss
+++ b/src/components/NoData/NoData.module.scss
@@ -1,0 +1,13 @@
+@import "@/styles/_index";
+
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+}
+
+.message {
+  color: $gray-200;
+}

--- a/src/components/NoData/NoData.tsx
+++ b/src/components/NoData/NoData.tsx
@@ -1,0 +1,22 @@
+import Image from "next/image";
+import cn from "@/utils/classNames";
+import { DEFAULT_PRODUCT_IMAGE } from "@/utils/constant";
+import styles from "./NoData.module.scss";
+
+type NoDataProps = {
+  message: string;
+};
+
+export default function NoData({ message }: NoDataProps) {
+  return (
+    <div className={cn(styles.container)}>
+      <Image
+        src={DEFAULT_PRODUCT_IMAGE}
+        width={200}
+        height={100}
+        alt='로고'
+      />
+      <div className={cn(styles.message)}>{message}</div>
+    </div>
+  );
+}

--- a/src/components/NoData/index.ts
+++ b/src/components/NoData/index.ts
@@ -1,0 +1,1 @@
+export { default as NoData } from "./NoData";


### PR DESCRIPTION
## Description
suspense와 ErrorBoundary를 이용하여 경계 아래에서 발생한 컴포넌트에 에러 및 로딩 시 폴백 UI를 보여주도록 구현

## Changes Made
- useInfiniteQuery 훅을 useSuspenseInfiniteQuery로 변경
- ErrorBoundary 클래스 생성
- 데이터가 없는 상태일 때 나타낼 NoData 컴포넌트 (각각 상황에 맞게 수정이 필요해 보임)

## Screenshots
<img width="1368" alt="스크린샷 2024-06-19 오후 5 30 40" src="https://github.com/Mogazoa-team20/mogazoa/assets/72126893/88a4cb1e-8050-478b-b490-6bc0ac563ace">
<img width="1372" alt="스크린샷 2024-06-19 오후 5 30 48" src="https://github.com/Mogazoa-team20/mogazoa/assets/72126893/4945a51d-2404-4ce9-8cda-6a933ecd1be9">
<img width="1370" alt="스크린샷 2024-06-19 오후 5 13 22" src="https://github.com/Mogazoa-team20/mogazoa/assets/72126893/8f46778c-de78-4843-be91-2a7f16030d6f">

## IssueNumber
