### PR TITLE
[#88] not-found 페이지 추가, error 페이지 디자인 추가 

### DIFF
--- a/src/app/commonErrorStyle.scss
+++ b/src/app/commonErrorStyle.scss
@@ -1,0 +1,52 @@
+@import "@/styles/_color";
+@import "@/styles/_mixins";
+@import "@/styles/_media";
+
+.errorContainer,
+.errorDescription {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.errorContainer {
+  height: calc(100vh - 100px);
+  gap: 40px;
+  @include respond-to(mobile) {
+    gap: 32px;
+  }
+
+  .errorTitleBox {
+    .errorTitle {
+      color: transparent;
+      background: $blue-gradient;
+      background-clip: text;
+    }
+
+    @include text-xl;
+    @include font-bold;
+    @include respond-to(mobile) {
+      @include text-lg;
+    }
+  }
+
+  .errorDescription {
+    gap: 4px;
+    @include text-normal;
+    @include font-normal;
+    @include respond-to(mobile) {
+      @include text-sm;
+    }
+  }
+
+  .errorButton {
+    width: 140px;
+
+    @include text-normal;
+    @include respond-to(mobile) {
+      width: 120px;
+      @include text-sm;
+    }
+  }
+}

--- a/src/app/commonErrorStyle.scss
+++ b/src/app/commonErrorStyle.scss
@@ -11,8 +11,9 @@
 }
 
 .errorContainer {
-  height: calc(100vh - 100px);
   gap: 40px;
+  height: calc(100vh - 100px);
+
   @include respond-to(mobile) {
     gap: 32px;
   }
@@ -26,6 +27,7 @@
 
     @include text-xl;
     @include font-bold;
+
     @include respond-to(mobile) {
       @include text-lg;
     }
@@ -33,8 +35,10 @@
 
   .errorDescription {
     gap: 4px;
+
     @include text-normal;
     @include font-normal;
+
     @include respond-to(mobile) {
       @include text-sm;
     }
@@ -44,8 +48,10 @@
     width: 140px;
 
     @include text-normal;
+
     @include respond-to(mobile) {
       width: 120px;
+
       @include text-sm;
     }
   }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,19 +1,29 @@
 "use client";
 
 import { useEffect } from "react";
+import "./commonErrorStyle.scss";
+import Button from "@/components/Button/Button";
 
 export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
   useEffect(() => {}, [error]);
 
   return (
-    <div>
-      <h2>에러가 발생하였습니다. 다시 시도해 주세요</h2>
-      <button
+    <div className='errorContainer'>
+      <h2 className='errorTitleBox'>
+        <span className='errorTitle'>에러가 발생했어요!</span>
+      </h2>
+      <div className='errorDescription'>
+        <p>페이지를 불러오는 과정에서 에러가 발생했어요.</p>
+        <p>다시 한 번 시도해 주세요</p>
+      </div>
+      <Button
+        className='errorButton'
+        styleType='secondary'
         type='button'
         onClick={() => reset()}
       >
-        Try again
-      </button>
+        재요청하기
+      </Button>
     </div>
   );
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import Button from "@/components/Button/Button";
+import "./commonErrorStyle.scss";
+
+export default function NotFoundPage() {
+  const router = useRouter();
+
+  return (
+    <div className='errorContainer'>
+      <h2 className='errorTitleBox'>
+        <span className='errorTitle'>페이지를 찾을 수 없어요!</span>
+      </h2>
+      <div className='errorDescription'>
+        <p>요청한 페이지를 찾는 데 실패했어요.</p>
+        <p>주소를 다시 한 번 확인해주세요.</p>
+      </div>
+      <Button
+        className='errorButton'
+        styleType='secondary'
+        onClick={() => router.replace("/")}
+      >
+        돌아가기
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description
- 기본 `error`, `not-found` 상황에서 노출될 페이지와 디자인을 추가했습니다. 
- `error`는 일단 기본 작성된 페이지 그대로 두었고 (`reset` 실행 버튼) `not-found`인 경우 `replace`를 통해 `/` 메인 페이지로 이동하는 버튼을 추가했습니다. `replace`를 통해 이동할 경우 잘못된 경로로 접근했던 기록이 삭제되어 뒤로가기 버튼을 눌러도 다시 잘못된 페이지에 접근하게 될 일이 없다고 합니다~! 
- 두 페이지에 사용되는 디자인이 동일해서 모듈 css로 생성하지 않았어요! 

## Changes Made
- 에러페이지(`not-found`, `error`) 공통 디자인 추가 
- `not-found` 페이지 생성
- 에러페이지 디자인 적용 

## Screenshots
![404](https://github.com/Mogazoa-team20/mogazoa/assets/112041983/8e39949a-533a-4429-abff-0ac0beb96c0d)
![에러페이지](https://github.com/Mogazoa-team20/mogazoa/assets/112041983/22f007f8-7b0f-4b34-97c7-a18622b73482)


## IssueNumber
[#88 ]
