### PR TITLE
[#94] fix: 간편 로그인 로직 에러 수정 

### DIFF
--- a/src/app/(auth)/_components/OauthSignInBox/OauthSignInBox.tsx
+++ b/src/app/(auth)/_components/OauthSignInBox/OauthSignInBox.tsx
@@ -7,7 +7,11 @@ import { OauthSignInButton } from "@/auth/_components/OauthSignInButton";
 import { GOOGLE_ICON, KAKAO_ICON } from "@/utils/constant";
 import styles from "./OauthSignInBox.module.scss";
 
-export default function OauthSignInBox() {
+type OauthSignInBoxProps = {
+  requestPage: string;
+};
+
+export default function OauthSignInBox({ requestPage }: OauthSignInBoxProps) {
   const router = useRouter();
   const handleKakaoSignIn = async () => {
     // 카카오 SDK 초기화
@@ -15,8 +19,9 @@ export default function OauthSignInBox() {
       window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_JS_KEY);
     }
     // 인가 코드 요청
+    console.log(requestPage);
     window.Kakao.Auth.authorize({
-      redirectUri: process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI,
+      redirectUri: `${process.env.NEXT_PUBLIC_DOMAIN}/${requestPage}`,
       scope: "openid",
     });
   };
@@ -28,7 +33,7 @@ export default function OauthSignInBox() {
       if (!localStorage.getItem("authCode") && code) {
         // 다시 redirect됐을 경우 요청 두 번 방지
         localStorage.setItem("authCode", code);
-        const result = await signIn("kakao", { redirect: false, callbackUrl: "/", code });
+        const result = await signIn("kakao", { redirect: false, callbackUrl: "/", code, requestPage });
 
         if (result?.status === 403) {
           localStorage.removeItem("authCode");

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -6,7 +6,7 @@ export default function SignInPage() {
   return (
     <div className={styles.container}>
       <SignInForm />
-      <OauthSignInBox />
+      <OauthSignInBox requestPage='signin' />
     </div>
   );
 }

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -6,7 +6,7 @@ export default function SignUpPage() {
   return (
     <div className={styles.container}>
       <SignUpForm />
-      <OauthSignInBox />
+      <OauthSignInBox requestPage='signup' />
     </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -53,6 +53,7 @@ export default async function RootLayout({
           src='https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js'
           integrity='sha384-TiCUE00h649CAMonG018J2ujOgDKW/kVWlChEuu4jK2vxfAAD0eZxzCKakxg55G4'
           crossOrigin='anonymous'
+          strategy='lazyOnload'
         />
       </body>
     </html>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -203,6 +203,8 @@ const authOptions: NextAuthOptions = {
           const data = await result.json();
 
           if (data.user) {
+            /* eslint-disable no-param-reassign */
+            user.id = data.user.id;
             return true;
           }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,6 +15,7 @@ const authOptions: NextAuthOptions = {
       id: "kakao",
       credentials: {
         code: { type: "text", label: "토큰" },
+        requestPage: { type: "text", label: "요청 페이지" },
       },
       async authorize(credentials) {
         try {
@@ -24,7 +25,7 @@ const authOptions: NextAuthOptions = {
               "Content-Type": "application/json",
             },
             body: JSON.stringify({
-              redirectUri: `${process.env.NEXTAUTH_URL}/signin`,
+              redirectUri: `${process.env.NEXTAUTH_URL}/${credentials?.requestPage}`,
               token: credentials?.code,
             }),
           });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -24,7 +24,7 @@ const authOptions: NextAuthOptions = {
               "Content-Type": "application/json",
             },
             body: JSON.stringify({
-              redirectUri: "http://localhost:3000/signin",
+              redirectUri: `${process.env.NEXTAUTH_URL}/signin`,
               token: credentials?.code,
             }),
           });
@@ -33,7 +33,7 @@ const authOptions: NextAuthOptions = {
           const user = data?.user;
 
           if (result.status === 403) {
-            return { redirect: "http://localhost:3000/oauth/signup/kakao" };
+            return { redirect: `${process.env.NEXTAUTH_URL}/oauth/signup/kakao` };
           }
 
           if (user) {


### PR DESCRIPTION
## Description
- 로컬-> 배포 환경으로 변화하며 생기는 오류를 수정했습니다. (oauth 로그인 제공 업체에서의 지정 `redirect uri` 수정, 로직 내부의 `uri` 중 변수를 사용하지 않은 부분-`localhost:3000/...`-등 수정)
- 구글 간편 로그인 성공시 유저 `id` 값에 구글에서 제공하는 `userId` 값이 지정되어 발생하던 에러(간편 로그인 후 유저 아이디를 사용하는 곳에서 발생하는 에러)를 수정했습니다. 
- `/signup` 페이지에서 간편로그인 버튼을 클릭할 경우 `redirect uri`가 `~/signin`으로 고정되어 있어 로그인 페이지로 이동하던 버그를 수정했습니다.
- 전체 레이아웃에 있는 카카오 SDK 스크립트 관련 `preload` 경고가 발생하는 문제를 해결... 한걸까요? 앱라우터에서 `preload` 관련 옵션을 설정하는 방법을 찾아봤는데 인터넷에 있는 건 대부분 스크립트 관련 얘기는 아닌 것 같아서 공식문서 참고하여 `strategy='lazyOnload'`를 추가했습니다. `afterInteracive`도 고민해봤는데 실제로 적용해봤을때 여전히 `preload` 관련 경고가 떴어요. 정확한 해결책을 아시는 분이 있다면 말씀해주세요 🥹

## Changes Made
- 코드 내부 `redirect uri` 수정 
- 환경 변수 추가 (`NEXT_PUBLIC_DOMAIN=http://localhost:3000`, 배포시에는 배포 주소로 추가해주세요! 기존 `KAKAO_REDIRECT_URI`는 삭제해도 될 것 같습니다)
- 카카오 스크립트 옵션 추가 
- 간편 로그인 컴포넌트 수정 
- 간편 로그인 로직 수정 

## Screenshots

## IssueNumber
[#94 ]
