### PR TITLE
fix: httpclient 로직 수정

### DIFF
--- a/src/app/(userpage)/user/[userId]/page.tsx
+++ b/src/app/(userpage)/user/[userId]/page.tsx
@@ -22,7 +22,7 @@ export default function UserPage({ params }: { params: { userId: number } }) {
   const { data } = useQuery({
     queryKey: ["userData", params.userId],
     queryFn: async () => {
-      const res = httpClient.get<UserDetail>(`users/${params.userId}`, {
+      const res = httpClient.get<UserDetail>(`/users/${params.userId}`, {
         headers: { Authorization: ACCESS_TOKEN ?? "" },
         cache: "no-cache",
       });

--- a/src/components/Upload/hooks/useUploadImageMutation.ts
+++ b/src/components/Upload/hooks/useUploadImageMutation.ts
@@ -11,8 +11,8 @@ const useUploadImageMutation = () => {
     mutationFn: async (image: Blob) => {
       const formData = new FormData();
       formData.append("image", image);
-      const response = await httpClient.post<{ url: string }, FormData>(
-        "images/upload",
+      const response = await httpClient.post<{ url: string }>(
+        "/images/upload",
         {
           headers: { Authorization: `Bearer ${accessToken}` },
         },

--- a/src/utils/httpClient.ts
+++ b/src/utils/httpClient.ts
@@ -6,15 +6,22 @@ export default class HttpClient {
   }
 
   private async sendRequest<T>(path: string, method: string, body?: BodyInit, options: RequestInit = {}): Promise<T> {
-    const newPath = path.at(0) === "/" ? path.slice(1) : path;
+    const { headers: headerOption, ...restOptions } = options;
+
+    const headers: HeadersInit = {
+      ...headerOption,
+    };
+
+    const requestOptions: RequestInit = {
+      method,
+      headers,
+      ...restOptions,
+      body,
+    };
+    console.log(body);
+
     try {
-      const requestOptions: RequestInit = {
-        method,
-        headers: { "Content-Type": "application/json", ...options.headers },
-        ...options,
-        body,
-      };
-      const response = await fetch(`${this.baseUrl}/${newPath}`, requestOptions);
+      const response = await fetch(`${this.baseUrl}${path}`, requestOptions);
       if (!response.ok) {
         throw new Error(`HTTP error ${response.status}`);
       }
@@ -35,6 +42,10 @@ export default class HttpClient {
 
   async put<T>(path: string, options: RequestInit = {}, body?: BodyInit): Promise<T> {
     return this.sendRequest<T>(path, "PUT", body, options);
+  }
+
+  async patch<T>(path: string, options: RequestInit = {}, body?: BodyInit): Promise<T> {
+    return this.sendRequest<T>(path, "PATCH", body, options);
   }
 
   async delete<T>(path: string, options: RequestInit = {}): Promise<T> {


### PR DESCRIPTION
## Description
- header처리와 body 처리 변경

## Changes Made
```ts
  private async sendRequest<T>(path: string, method: string, body?: BodyInit, options: RequestInit = {}): Promise<T> {
    const { headers: headerOption, ...restOptions } = options;

    const headers: HeadersInit = {
      ...headerOption,
    };

    const requestOptions: RequestInit = {
      method,
      headers,
      ...restOptions,
      body,
    };
    console.log(body);

```

## Screenshots

## IssueNumber
[#이슈번호]
