### PR TITLE
refactor: 카카오 스크립트 관련 수정 

### DIFF
--- a/src/app/(auth)/_components/OauthSignInBox/OauthSignInBox.tsx
+++ b/src/app/(auth)/_components/OauthSignInBox/OauthSignInBox.tsx
@@ -14,12 +14,12 @@ type OauthSignInBoxProps = {
 export default function OauthSignInBox({ requestPage }: OauthSignInBoxProps) {
   const router = useRouter();
   const handleKakaoSignIn = async () => {
-    // 카카오 SDK 초기화
+    if (!window) return;
+
     if (!window.Kakao.isInitialized()) {
       window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_JS_KEY);
     }
-    // 인가 코드 요청
-    console.log(requestPage);
+
     window.Kakao.Auth.authorize({
       redirectUri: `${process.env.NEXT_PUBLIC_DOMAIN}/${requestPage}`,
       scope: "openid",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
-import Script from "next/script";
 import { getServerSession } from "next-auth/next";
 import { FloatingButton } from "@/components/FloatingButton";
 import { Gnb } from "@/components/Gnb";
 import authOptions from "@/lib/auth";
 import AuthProvider from "@/lib/AuthProvider";
+import KakaoScript from "@/lib/KakaoScript";
 import Providers from "@/lib/Providers";
 import "@/styles/_reset.scss";
 import "@/styles/_common.scss";
@@ -20,13 +20,6 @@ const pretendard = localFont({
   src: "../../public/fonts/Pretendard-Regular.woff2",
   display: "swap",
 });
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
-declare global {
-  interface Window {
-    Kakao: any;
-  }
-}
 
 export default async function RootLayout({
   children,
@@ -48,13 +41,7 @@ export default async function RootLayout({
             <FloatingButton initialSession={session} />
           </Providers>
         </AuthProvider>
-        <Script
-          async
-          src='https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js'
-          integrity='sha384-TiCUE00h649CAMonG018J2ujOgDKW/kVWlChEuu4jK2vxfAAD0eZxzCKakxg55G4'
-          crossOrigin='anonymous'
-          strategy='lazyOnload'
-        />
+        <KakaoScript />
       </body>
     </html>
   );

--- a/src/app/product/utils/kakao.ts
+++ b/src/app/product/utils/kakao.ts
@@ -4,7 +4,10 @@ export const shareKakao = () => {
   if (!window) return;
   const { Kakao } = window;
   const url = window.location.href;
-  Kakao.init(process.env.NEXT_PUBLIC_KAKAO_JS_KEY);
+
+  if (!Kakao.isInitialized()) {
+    Kakao.init(process.env.NEXT_PUBLIC_KAKAO_JS_KEY);
+  }
 
   Kakao.Share.sendDefault({
     objectType: "feed",

--- a/src/lib/KakaoScript.tsx
+++ b/src/lib/KakaoScript.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import Script from "next/script";
+
+export default function KakaoScript() {
+  const onLoad = () => {
+    window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_JS_KEY);
+  };
+
+  return (
+    <Script
+      async
+      src='https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js'
+      integrity='sha384-TiCUE00h649CAMonG018J2ujOgDKW/kVWlChEuu4jK2vxfAAD0eZxzCKakxg55G4'
+      crossOrigin='anonymous'
+      strategy='lazyOnload'
+      onLoad={onLoad}
+    />
+  );
+}

--- a/src/types/auth.d.ts
+++ b/src/types/auth.d.ts
@@ -16,3 +16,10 @@ export declare module "@auth/core/jwt" {
     user: { id: number };
   }
 }
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export declare global {
+  interface Window {
+    Kakao: any;
+  }
+}


### PR DESCRIPTION
## Description
- 카카오 스크립트를 별도 컴포넌트로 분리하여 `load`됐을때 자동으로 초기화를 실행하도록 수정했습니다. 중복 초기화 선언을 방지하기 위해 공유하기 로직 초기화 부분을 `if`문으로 처리(초기화가 되지 않았을 경우에만 실행)했습니다.
- `layout.tsx` 파일에 선언되어있던 카카오 타입을 `auth.d.ts` 파일로 분리했습니다. (따로 `.d.ts` 파일 추가해야하나 싶은데 하나밖에 없어서.....일단 있는 파일에 추가했어요!)

## Changes Made
- `KakaoScript.tsx` 컴포넌트 파일 생성 
- kakao 초기화 선언 관련 수정 
- 카카오 타입 선언 코드를 `d.ts` 파일로 이동
- 불필요한 코드 삭제 

## Screenshots

## IssueNumber
