### PR TITLE
fix: 사파리에서 pretendard 글꼴로 나타나지 않는 문제 수정 

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,7 @@ export const metadata: Metadata = {
 
 const pretendard = localFont({
   src: "../../public/fonts/Pretendard-Regular.woff2",
+  variable: "--font-pretendard",
   display: "swap",
 });
 

--- a/src/styles/_common.scss
+++ b/src/styles/_common.scss
@@ -5,7 +5,8 @@
   box-sizing: border-box;
   padding: 0;
   margin: 0;
-  font-family: var(--font-pretendard);
+  font-family: var(--font-pretendard), "맑은 고딕", "malgun gothic", "AppleGothicNeoSD", "Apple SD 산돌고딕 Neo",
+    "Microsoft NeoGothic", "Droid sans", sans-serif;
 }
 
 body {

--- a/src/styles/_common.scss
+++ b/src/styles/_common.scss
@@ -5,7 +5,7 @@
   box-sizing: border-box;
   padding: 0;
   margin: 0;
-  font-family: pretendard;
+  font-family: var(--font-pretendard);
 }
 
 body {


### PR DESCRIPTION
## Description
- `pretendard` 폰트 변수명 추가 후 스타일에 적용
- 그외 os별 fallbaclk 폰트 설정을 추가했습니다. 

## Changes Made
- 상기와 동일함 

## Screenshots

## IssueNumber