### PR TITLE
fix: statistic Card 별점 평균 외 나머지 소수점 제거 (#22)

### DIFF
--- a/src/components/Card/Statistics/Statistics.tsx
+++ b/src/components/Card/Statistics/Statistics.tsx
@@ -58,7 +58,7 @@ export default function Statistics({ title, rating, reviewCount, favoriteCount, 
               fill
             />
           </figure>
-          <span>{mainContent?.toFixed(1)}</span>
+          {title === "별점 평균" ? <span>{mainContent?.toFixed(1)}</span> : <span>{mainContent?.toFixed(0)}</span>}
         </div>
       </div>
       {title === "별점 평균" ? (


### PR DESCRIPTION
## Description
상품 상세페이지 별점평균 외 나머지 소수점 제거

## Changes Made
상품 상세페이지 별점평균 외 나머지 소수점 제거

## Screenshots
![image](https://github.com/Mogazoa-team20/mogazoa/assets/33426203/581b3b7b-bb4c-4d12-9705-dbff6e82a276)

## IssueNumber
[#22]
