### PR TITLE
fix: Toast 관련 오류 수정 + auth 페이지 수정(toast 사용)

### DIFF
--- a/src/app/(auth)/_components/OauthSignInBox/OauthSignInBox.tsx
+++ b/src/app/(auth)/_components/OauthSignInBox/OauthSignInBox.tsx
@@ -44,7 +44,7 @@ export default function OauthSignInBox({ requestPage }: OauthSignInBoxProps) {
       }
     };
     handleKakaoCallback();
-  }, [router]);
+  }, [router, requestPage]);
 
   return (
     <div className={styles.container}>

--- a/src/app/(auth)/oauth/signup/[provider]/_components/OauthSignUpForm/OauthSignUpForm.tsx
+++ b/src/app/(auth)/oauth/signup/[provider]/_components/OauthSignUpForm/OauthSignUpForm.tsx
@@ -50,7 +50,7 @@ export default function OauthSignUpForm({ provider, token }: OauthSignUpFormProp
   };
 
   useEffect(() => {
-    const toastInstance = new Toast();
+    const toastInstance = Toast.getInstance();
     setToast(toastInstance);
   }, []);
 

--- a/src/app/(auth)/oauth/signup/[provider]/_components/OauthSignUpForm/OauthSignUpForm.tsx
+++ b/src/app/(auth)/oauth/signup/[provider]/_components/OauthSignUpForm/OauthSignUpForm.tsx
@@ -2,13 +2,13 @@
 
 import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { AlertModal } from "@/app/(auth)/_components/AlertModal";
 import { LabelBox } from "@/app/(auth)/_components/LabelBox";
 import { SIGNUP_VALIDATION } from "@/app/(auth)/constants";
 import Button from "@/components/Button/Button";
 import Input from "@/components/Input/Input";
+import { Toast } from "@/components/Toast";
 import styles from "./OauthSignUpForm.module.scss";
 
 type OauthSignUpFormProps = {
@@ -21,8 +21,7 @@ type OauthSignUpFormData = {
 };
 
 export default function OauthSignUpForm({ provider, token }: OauthSignUpFormProps) {
-  const [isModal, setIsModal] = useState(false);
-  const [modalMessage, setModalMessage] = useState("");
+  const [toast, setToast] = useState<Toast | null>(null);
   const router = useRouter();
   const {
     register,
@@ -30,10 +29,6 @@ export default function OauthSignUpForm({ provider, token }: OauthSignUpFormProp
     formState: { isValid, errors, isSubmitting },
     setError,
   } = useForm<OauthSignUpFormData>({ mode: "onBlur" });
-
-  const handleModalClose = () => {
-    setIsModal(false);
-  };
 
   const onSubmit = async (data: OauthSignUpFormData) => {
     const result = await signIn("easySignup", {
@@ -44,23 +39,29 @@ export default function OauthSignUpForm({ provider, token }: OauthSignUpFormProp
     });
 
     if (result?.error && result?.error.includes("닉네임")) {
+      toast?.error(result.error);
       setError("nickname", { message: result.error });
     } else if (result?.error) {
-      setModalMessage(result.error);
-      setIsModal(true);
+      toast?.error(result.error);
     } else {
+      toast?.success("회원가입이 완료되었습니다.");
       router.push("/");
     }
   };
 
+  useEffect(() => {
+    const toastInstance = new Toast();
+    setToast(toastInstance);
+  }, []);
+
+  useEffect(() => {
+    if (toast) {
+      toast?.info("추가 정보 등록 후 가입이 가능합니다.");
+    }
+  }, [toast]);
+
   return (
     <>
-      <AlertModal
-        isModal={isModal}
-        handleClose={handleModalClose}
-      >
-        {modalMessage}
-      </AlertModal>
       <form
         className={styles.container}
         onSubmit={handleSubmit(onSubmit)}

--- a/src/app/(auth)/signin/_components/SignInForm/SignInForm.tsx
+++ b/src/app/(auth)/signin/_components/SignInForm/SignInForm.tsx
@@ -18,7 +18,7 @@ type SignInFormData = {
 };
 
 export default function SignInForm() {
-  const [toast, SetToast] = useState<Toast | null>(null);
+  const [toast, setToast] = useState<Toast | null>(null);
   const {
     register,
     formState: { isValid, errors, isSubmitting },
@@ -44,8 +44,8 @@ export default function SignInForm() {
   };
 
   useEffect(() => {
-    const toastInstance = new Toast();
-    SetToast(toastInstance);
+    const toastInstance = Toast.getInstance();
+    setToast(toastInstance);
   }, []);
 
   return (

--- a/src/app/(auth)/signin/_components/SignInForm/SignInForm.tsx
+++ b/src/app/(auth)/signin/_components/SignInForm/SignInForm.tsx
@@ -79,6 +79,7 @@ export default function SignInForm() {
             rules={SIGNIN_VALIDATION.PASSWORD}
             errors={errors}
             placeholder='비밀번호를 입력해 주세요'
+            autoComplete='off'
           />
         </LabelBox>
       </div>

--- a/src/app/(auth)/signin/_components/SignInForm/SignInForm.tsx
+++ b/src/app/(auth)/signin/_components/SignInForm/SignInForm.tsx
@@ -2,12 +2,14 @@
 
 import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { LabelBox } from "@/app/(auth)/_components/LabelBox";
 import { SIGNIN_VALIDATION } from "@/app/(auth)/constants";
 import Button from "@/components/Button/Button";
 import Input from "@/components/Input/Input";
 import PasswordInput from "@/components/Input/PasswordInput";
+import { Toast } from "@/components/Toast";
 import styles from "./SignInForm.module.scss";
 
 type SignInFormData = {
@@ -16,6 +18,7 @@ type SignInFormData = {
 };
 
 export default function SignInForm() {
+  const [toast, SetToast] = useState<Toast | null>(null);
   const {
     register,
     formState: { isValid, errors, isSubmitting },
@@ -34,10 +37,16 @@ export default function SignInForm() {
     if (result?.ok) {
       router.push("/");
     } else {
+      toast?.error("이메일 혹은 비밀번호를 확인해주세요!");
       setError("email", { type: "loginError", message: "이메일 혹은 비밀번호를 확인해주세요." });
       setError("password", { type: "loginError" });
     }
   };
+
+  useEffect(() => {
+    const toastInstance = new Toast();
+    SetToast(toastInstance);
+  }, []);
 
   return (
     <form

--- a/src/app/(auth)/signup/_components/SignUpForm/SignUpForm.tsx
+++ b/src/app/(auth)/signup/_components/SignUpForm/SignUpForm.tsx
@@ -114,6 +114,7 @@ export default function SignUpForm() {
               rules={SIGNUP_VALIDATION.password}
               errors={errors}
               placeholder='비밀번호를 입력해 주세요'
+              autoComplete='off'
             />
           </LabelBox>
           <LabelBox
@@ -127,6 +128,7 @@ export default function SignUpForm() {
               rules={PASSWORD_CONFIRMATION_VALIDATION}
               errors={errors}
               placeholder='비밀번호를 한번 더 입력해 주세요'
+              autoComplete='off'
             />
           </LabelBox>
         </div>

--- a/src/app/(auth)/signup/_components/SignUpForm/SignUpForm.tsx
+++ b/src/app/(auth)/signup/_components/SignUpForm/SignUpForm.tsx
@@ -2,14 +2,14 @@
 
 import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { AlertModal } from "@/app/(auth)/_components/AlertModal";
 import { LabelBox } from "@/app/(auth)/_components/LabelBox";
 import { SIGNUP_VALIDATION } from "@/app/(auth)/constants";
 import Button from "@/components/Button/Button";
 import Input from "@/components/Input/Input";
 import PasswordInput from "@/components/Input/PasswordInput";
+import { Toast } from "@/components/Toast";
 import styles from "./SignUpForm.module.scss";
 
 type SignUpFormData = {
@@ -20,8 +20,7 @@ type SignUpFormData = {
 };
 
 export default function SignUpForm() {
-  const [isModal, setIsModal] = useState(false);
-  const [modalMessage, setModalMessage] = useState("");
+  const [toast, setToast] = useState<Toast | null>(null);
   const {
     register,
     handleSubmit,
@@ -30,10 +29,6 @@ export default function SignUpForm() {
     formState: { isValid, errors, isSubmitting },
   } = useForm<SignUpFormData>({ mode: "onBlur" });
   const router = useRouter();
-
-  const handleModalClose = () => {
-    setIsModal(false);
-  };
 
   const PASSWORD_CONFIRMATION_VALIDATION = {
     ...SIGNUP_VALIDATION.passwordConfirmation,
@@ -55,8 +50,7 @@ export default function SignUpForm() {
     });
 
     if (result?.error) {
-      setModalMessage(result.error);
-      setIsModal(true);
+      toast?.error(result.error);
 
       if (result.error.includes("닉네임")) {
         setError("nickname", { message: result.error });
@@ -64,18 +58,18 @@ export default function SignUpForm() {
         setError("email", { message: result.error });
       }
     } else {
+      toast?.success("회원가입이 완료되었습니다!");
       router.push("/");
     }
   };
 
+  useEffect(() => {
+    const toastInstance = new Toast();
+    setToast(toastInstance);
+  }, []);
+
   return (
     <>
-      <AlertModal
-        isModal={isModal}
-        handleClose={handleModalClose}
-      >
-        {modalMessage}
-      </AlertModal>
       <form
         className={styles.container}
         onSubmit={handleSubmit(onSubmit)}

--- a/src/app/(auth)/signup/_components/SignUpForm/SignUpForm.tsx
+++ b/src/app/(auth)/signup/_components/SignUpForm/SignUpForm.tsx
@@ -64,7 +64,7 @@ export default function SignUpForm() {
   };
 
   useEffect(() => {
-    const toastInstance = new Toast();
+    const toastInstance = Toast.getInstance();
     setToast(toastInstance);
   }, []);
 

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,53 +1,65 @@
-import { createRoot } from "react-dom/client";
+import { createRoot, Root } from "react-dom/client";
 import { v4 as uuid } from "uuid";
 import { ToastList } from "./ToastList";
 import { Message } from "./type";
 
 class Toast {
-  private rootElement: HTMLElement;
+  private static instance: Toast;
 
-  private root: ReturnType<typeof createRoot>;
+  private static root: Root | null = null;
 
-  private messages: Message[];
+  private messages: Message[] = [];
 
-  private autoCloseIds: { [key: string]: number };
+  private timeoutIds: { [key: string]: number } = {};
 
-  constructor() {
-    this.rootElement = document.getElementById("toast") as HTMLElement;
-    this.root = createRoot(this.rootElement);
-    this.messages = [];
-    this.autoCloseIds = {};
+  private constructor() {
+    if (!Toast.root) {
+      const rootElement = document.getElementById("toast");
+      if (!rootElement) {
+        const newRootElement = document.createElement("div");
+        newRootElement.id = "toast";
+        document.body.appendChild(newRootElement);
+        Toast.root = createRoot(newRootElement);
+      } else {
+        Toast.root = createRoot(rootElement);
+      }
+    }
 
     this.closeToast = this.closeToast.bind(this);
+  }
+
+  static getInstance(): Toast {
+    if (!Toast.instance) {
+      Toast.instance = new Toast();
+    }
+    return Toast.instance;
   }
 
   private closeToast(deleteId: string) {
     const deleteIndex = this.messages.findIndex(({ id }) => id === deleteId);
     if (deleteIndex !== -1) {
-      clearTimeout(this.autoCloseIds[deleteId]);
-      delete this.autoCloseIds[deleteId];
+      clearTimeout(this.timeoutIds[deleteId]);
+      delete this.timeoutIds[deleteId];
       this.messages.splice(deleteIndex, 1);
       this.renderToasts();
     }
   }
 
   private renderToasts() {
-    this.root.render(
-      <ToastList
-        messages={this.messages}
-        closeToast={this.closeToast}
-      />,
-    );
+    if (Toast.root) {
+      Toast.root.render(
+        <ToastList
+          messages={this.messages}
+          closeToast={this.closeToast}
+        />,
+      );
+    }
   }
 
   private autoCloseToast(id: string) {
-    this.autoCloseIds[id] = setTimeout(
-      () => {
-        this.closeToast(id);
-      },
-      3000,
-      this,
-    );
+    this.timeoutIds[id] = window.setTimeout(() => {
+      this.closeToast(id);
+    }, 3000);
   }
 
   success(message: string) {

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -10,23 +10,25 @@ class Toast {
 
   private messages: Message[];
 
+  private autoCloseIds: { [key: string]: number };
+
   constructor() {
     this.rootElement = document.getElementById("toast") as HTMLElement;
     this.root = createRoot(this.rootElement);
     this.messages = [];
+    this.autoCloseIds = {};
 
     this.closeToast = this.closeToast.bind(this);
   }
 
   private closeToast(deleteId: string) {
     const deleteIndex = this.messages.findIndex(({ id }) => id === deleteId);
-    this.messages.splice(deleteIndex, 1);
-    this.root.render(
-      <ToastList
-        messages={this.messages}
-        closeToast={this.closeToast}
-      />,
-    );
+    if (deleteIndex !== -1) {
+      clearTimeout(this.autoCloseIds[deleteId]);
+      delete this.autoCloseIds[deleteId];
+      this.messages.splice(deleteIndex, 1);
+      this.renderToasts();
+    }
   }
 
   private renderToasts() {
@@ -39,7 +41,7 @@ class Toast {
   }
 
   private autoCloseToast(id: string) {
-    setTimeout(
+    this.autoCloseIds[id] = setTimeout(
       () => {
         this.closeToast(id);
       },

--- a/src/components/Toast/ToastBox/ToastBox.module.scss
+++ b/src/components/Toast/ToastBox/ToastBox.module.scss
@@ -22,10 +22,10 @@
   }
 
   &.visible {
-    animation: identifier 3s;
+    animation: toast 3s;
   }
 
-  @keyframes identifier {
+  @keyframes toast {
     0% {
       margin-bottom: -50px;
       opacity: 0;
@@ -41,11 +41,7 @@
       transform: scale(1);
     }
 
-    20% {
-      margin-bottom: 0;
-      opacity: 1;
-    }
-
+    20%,
     80% {
       margin-bottom: 0;
       opacity: 1;


### PR DESCRIPTION
## Description
-  `Toast` 기존에 작성한 코드가 매 페이지마다 `createRoot`를 실행하는 문제점이 있어서 한 번 인스턴스가 생성되면 생성된 인스턴스를 받아 사용하는 것으로 수정하였습니다. 이와 관련해서 사용법도 약간 수정이 필요한데요! `useEffect` 훅에서 `const toastInstance = new Toast();`로 작성해야 했던 부분을 `const toastInstance = Toast.getInstance();` 이렇게만 변경하면 됩니다!
```typescript
import { Toast } from "@/components/Toast";

// ...

const [toast, setToast] = useState<Toast | null>(null);

useEffect(() => {
  const toastInstance = Toast.getInstance(); // 이 부분만 변경!
  setToast(toastInstance);
}, []);
```
- `auth` 관련 페이지 컴포넌트에서 안내/에러 모달을 토스트로 변경하고 누락된 디펜던시 리스트와 패스워드 인풋의 `autoComplete` 속성을 추가했습니다. 

## Changes Made
- `Toast` 개별 토스트에 `clearTimeout` 추가(자동 삭제 및 유저가 삭제하는 경우 모두 포함)
- `Toast`에 `getInstance()` 메서드 추가
- `auth` 관련 페이지 컴포넌트 수정 및 토스트 알림 추가 
- `ToastBox` 애니메이션 변수명 수정, 불필요한 반복 코드 삭제 

## Screenshots

## IssueNumber

