### PR TITLE
fix: 간편 로그인 후 accessToken이 제대로 연결되지 않는 문제 수정

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -40,7 +40,7 @@ const authOptions: NextAuthOptions = {
           if (user) {
             return {
               ...user,
-              accessToken: user.accessToken,
+              accessToken: data.accessToken,
             };
           }
 
@@ -206,6 +206,8 @@ const authOptions: NextAuthOptions = {
           if (data.user) {
             /* eslint-disable no-param-reassign */
             user.id = data.user.id;
+            user.accessToken = data.accessToken;
+
             return true;
           }
 


### PR DESCRIPTION
## Description
- 잘못된 accessToken이 연결되어 있어 간편로그인시 인증이 필요한 페이지에 접근이 되지 않는 부분을 수정했습니다.

## Changes Made
- 리소스 서버에서 받아온 accessToken을 세션에 다시 저장하도록 수정
- kakao 로그인시 받아오는 accessToken이 잘못되어있어 함께 수정함 

## Screenshots

## IssueNumber
