### PR TITLE
accessToken이 get요청 되어 팔로우 상태가 false로 되는 에러 수정

### DIFF
--- a/src/app/(userpage)/user/[userId]/components/UserInfo/UserInfo.tsx
+++ b/src/app/(userpage)/user/[userId]/components/UserInfo/UserInfo.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import { useMutation, useQueryClient } from "@tanstack/react-query";

--- a/src/app/(userpage)/user/[userId]/page.tsx
+++ b/src/app/(userpage)/user/[userId]/page.tsx
@@ -1,17 +1,15 @@
 "use client";
 
-/* eslint-disable no-restricted-imports */
-
 import { useQuery } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
-import React from "react";
+import React, { useEffect } from "react";
+import { UserDetail } from "@/app/(userpage)/types";
 import Activity from "@/components/Card/Activity/Activity";
 import cn from "@/utils/classNames";
 import HttpClient from "@/utils/httpClient";
 import UserActivityList from "./components/UserActivityList/UserActivityList";
 import UserInfo from "./components/UserInfo/UserInfo";
 import styles from "./UserPage.module.scss";
-import { UserDetail } from "../../types";
 
 export default function UserPage({ params }: { params: { userId: number } }) {
   const httpClient = new HttpClient(process.env.NEXT_PUBLIC_BASE_URL!);
@@ -23,7 +21,7 @@ export default function UserPage({ params }: { params: { userId: number } }) {
     headers.Authorization = `Bearer ${accessToken}`;
   }
 
-  const { data } = useQuery({
+  const { data, refetch } = useQuery({
     queryKey: ["userData", params.userId],
     queryFn: async () => {
       const res = httpClient.get<UserDetail>(`/users/${params.userId}`, {
@@ -33,6 +31,12 @@ export default function UserPage({ params }: { params: { userId: number } }) {
       return res;
     },
   });
+
+  useEffect(() => {
+    if (accessToken !== undefined) {
+      refetch();
+    }
+  }, [accessToken, data]);
 
   return (
     <div className={cn(styles.container)}>


### PR DESCRIPTION
## Description
accessToken이 get요청 되어 팔로우 상태가 false로 되는 에러 수정

## Changes Made
useQuery가 클라이언트 사이드에서만 돌아가서 서버에서 쿼리를 비동기적으로 받아오는게 불가능했음
useQuery의 refetch를 사용해서 accessToken이 있을 때 데이터 최신화

## Screenshots

## IssueNumber
[#86]
