### PR TITLE
feat: 토스트 개수 제한 추가

### DIFF
--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,7 +1,10 @@
 import { createRoot, Root } from "react-dom/client";
 import { v4 as uuid } from "uuid";
 import { ToastList } from "./ToastList";
-import { Message } from "./type";
+import { Message, ToastType } from "./type";
+
+const TOAST_DURATION = 3000;
+const MAX_TOAST = 5;
 
 class Toast {
   private static instance: Toast;
@@ -59,51 +62,43 @@ class Toast {
   private autoCloseToast(id: string) {
     this.timeoutIds[id] = window.setTimeout(() => {
       this.closeToast(id);
-    }, 3000);
+    }, TOAST_DURATION);
+  }
+
+  private showToast(message: string, type: ToastType) {
+    if (this.messages.length >= MAX_TOAST) {
+      const oldestToast = this.messages.shift();
+
+      if (oldestToast) {
+        clearTimeout(this.timeoutIds[oldestToast.id]);
+        delete this.timeoutIds[oldestToast.id];
+      }
+    }
+
+    const id = uuid();
+    this.messages.push({
+      id,
+      message,
+      type,
+    });
+    this.renderToasts();
+    this.autoCloseToast(id);
   }
 
   success(message: string) {
-    const id = uuid();
-    this.messages.push({
-      id,
-      message,
-      type: "success",
-    });
-    this.renderToasts();
-    this.autoCloseToast(id);
+    this.showToast(message, "success");
   }
 
   caution(message: string) {
-    const id = uuid();
-    this.messages.push({
-      id,
-      message,
-      type: "caution",
-    });
-    this.renderToasts();
-    this.autoCloseToast(id);
+    this.showToast(message, "caution");
   }
 
   error(message: string) {
-    const id = uuid();
-    this.messages.push({
-      id,
-      message,
-      type: "error",
-    });
-    this.renderToasts();
-    this.autoCloseToast(id);
+    this.showToast(message, "error");
   }
 
   info(message: string) {
-    const id = uuid();
-    this.messages.push({
-      id,
-      message,
-      type: "info",
-    });
-    this.renderToasts();
-    this.autoCloseToast(id);
+    this.showToast(message, "info");
   }
 }
 


### PR DESCRIPTION
## Description
- 토스트 개수가 5개까지만 노출되도록 했습니다. 5개 이상이 생성될 경우 가장 오래된 토스트를 삭제합니다. 

## Changes Made
- `showToast` 공통 로직 분리(토스트 생성) 및 5개 생성 제한 추가
- 토스트 유지 시간 및 최대 토스트 개수 상수화 

## Screenshots

## IssueNumber
